### PR TITLE
power 2D plain text reader; changing & to - for optional args

### DIFF
--- a/nbodykit/files.py
+++ b/nbodykit/files.py
@@ -306,3 +306,49 @@ class HaloFile(object):
             ff.seek(self.nhalo * 12, 1)
             return numpy.fromfile(ff, count=self.nhalo, dtype=('f4', 3))
 
+def ReadPower2DPlainText(filename):
+    """
+    Reads the plain text storage of a 2D power spectrum measurement,
+    as output by the `nbodykit.plugins.Power2DStorage` plugin
+    
+    Returns
+    -------
+    data : dict
+        Dictionary 
+    """
+    toret = {}
+    with open(filename, 'r') as ff:
+        
+        # read number of k and mu bins are first line
+        Nk, Nmu = map(int, ff.readline().split())
+        # names of data columns on second line
+        columns = ff.readline().split()
+        
+        # read the column data
+        for name in columns: toret[name] = numpy.empty(Nk*Nmu)
+        for i in range(Nk*Nmu):
+            fields = map(float, ff.readline().split())
+            for icol, val in enumerate(fields):
+                toret[columns[icol]][i] = val
+                
+        # reshape properly to (Nk, Nmu)
+        for name in columns:        
+            toret[name] = toret[name].reshape((Nk,Nmu))
+        
+        # read the edges for k and mu bins
+        edges = []
+        edges_names = ['kedges', 'muedges']
+        for i, name in enumerate(edges_names):
+ 
+            if ff.readline().strip() == name:
+                N = int(ff.readline())
+                edges.append(numpy.empty(N))
+                for j in range(N):
+                    edges[i][j] = float(ff.readline())
+        toret['edges'] = edges
+        
+    return toret
+                
+            
+                
+        

--- a/nbodykit/plugins/HaloFilePainter.py
+++ b/nbodykit/plugins/HaloFilePainter.py
@@ -13,13 +13,13 @@ class HaloFilePainter(InputPainter):
     def register(kls):
         
         h = kls.add_parser(kls.field_type, 
-            usage=kls.field_type+":path:logMmin:logMmax:m0[:&rsd=[x|y|z]]",
+            usage=kls.field_type+":path:logMmin:logMmax:m0[:-rsd=[x|y|z]]",
             )
         h.add_argument("path", help="path to file")
         h.add_argument("logMmin", type=float, help="log10 min mass")
         h.add_argument("logMmax", type=float, help="log10 max mass")
         h.add_argument("m0", type=float, help="mass mass of a particle")
-        h.add_argument("&rsd", 
+        h.add_argument("-rsd", 
             choices="xyz", help="direction to do redshift distortion")
         h.set_defaults(klass=kls)
     

--- a/nbodykit/plugins/TPMSnapshotPainter.py
+++ b/nbodykit/plugins/TPMSnapshotPainter.py
@@ -11,9 +11,9 @@ class TPMSnapshotPainter(InputPainter):
     @classmethod
     def register(kls):
         h = kls.add_parser(kls.field_type, 
-            usage=kls.field_type+":path[:&rsd=[x|y|z]]")
+            usage=kls.field_type+":path[:-rsd=[x|y|z]]")
         h.add_argument("path", help="path to file")
-        h.add_argument("&rsd", 
+        h.add_argument("-rsd", 
             choices="xyz", default=None, help="direction to do redshift distortion")
         h.set_defaults(klass=kls)
 

--- a/nbodykit/plugins/__init__.py
+++ b/nbodykit/plugins/__init__.py
@@ -49,7 +49,7 @@ class InputPainter:
     
     from argparse import ArgumentParser
 
-    parser = ArgumentParser("", prefix_chars="-&", add_help=False)
+    parser = ArgumentParser("", add_help=False)
     subparsers = parser.add_subparsers()
     field_type = None
 
@@ -81,7 +81,7 @@ class InputPainter:
     @classmethod
     def add_parser(kls, name, usage):
         return kls.subparsers.add_parser(name, 
-                usage=usage, add_help=False, prefix_chars="&")
+                usage=usage, add_help=False)
     
     @classmethod
     def format_help(kls):


### PR DESCRIPTION
* added a function to files.py to read the 2D power plain text file
* reverting back to '-' rather than '&' for optional arguments since the later doesn't work in bash