### PR TITLE
combining measurepower for 1d and 2d cases; `los` option for power.py

### DIFF
--- a/nbodykit/measurepower.py
+++ b/nbodykit/measurepower.py
@@ -4,106 +4,107 @@ from pypm.particlemesh import ParticleMesh
 from pypm.transfer import TransferFunction
 from mpi4py import MPI
 
-def measurepower(pm, c1, c2, binshift=0.0, shotnoise=0.0):
-    """ Measure power spectrum from density field painted on pm 
-
-        The power spectrum is measured in bins of k, from 0 to the Nyquist (Nmesh / 2)
-        The units is consistent with the units of the BoxSize.
-
-        Parameters
-        ----------
-        pm : ParticleMesh
-            A particle mesh object
-
-        complex: array_like
-            the complex fourier space field to measure power from.
-
-        binshift   : float
-            shift the center of bins by this fraction if a bin width
-
-        shotnoise : 0.0
-            remove the shot noise contribution from the final power spectrum
-            The shot noise is (pm.BoxSize) ** 3 / Ntot, where Ntot is the total
-            number of particles.
-            
-        Notes
-        -----
-        After the measurement the density field is destroyed.
-
-    """
- 
-    wout = numpy.empty(pm.Nmesh//2)
-    psout = numpy.empty(pm.Nmesh//2)
-    Nout = numpy.empty(pm.Nmesh//2)
+# def measurepower(pm, c1, c2, binshift=0.0, shotnoise=0.0):
+#     """ Measure power spectrum from density field painted on pm
+#
+#         The power spectrum is measured in bins of k, from 0 to the Nyquist (Nmesh / 2)
+#         The units is consistent with the units of the BoxSize.
+#
+#         Parameters
+#         ----------
+#         pm : ParticleMesh
+#             A particle mesh object
+#
+#         complex: array_like
+#             the complex fourier space field to measure power from.
+#
+#         binshift   : float
+#             shift the center of bins by this fraction if a bin width
+#
+#         shotnoise : 0.0
+#             remove the shot noise contribution from the final power spectrum
+#             The shot noise is (pm.BoxSize) ** 3 / Ntot, where Ntot is the total
+#             number of particles.
+#
+#         Notes
+#         -----
+#         After the measurement the density field is destroyed.
+#
+#     """
+#
+#     wout = numpy.empty(pm.Nmesh//2)
+#     psout = numpy.empty(pm.Nmesh//2)
+#     Nout = numpy.empty(pm.Nmesh//2)
+#
+#     wedges = numpy.linspace(0, numpy.pi, wout.size + 1, endpoint=True)
+#     wedges += binshift * wedges[1]
+#
+#     w2edges = wedges ** 2
+#
+#     wsum = numpy.zeros(len(psout))
+#     P = numpy.zeros(len(psout))
+#     N = numpy.zeros(len(psout))
+#     for row in range(len(pm.w[0])):
+#         # pickup the singular plane that is single counted (r2c transform)
+#         singular = pm.w[2][-1] == 0
+#
+#         scratch = numpy.float64(pm.w[0][row] ** 2)
+#         for wi in pm.w[1:]:
+#             scratch = scratch + wi[0] ** 2
+#
+#         # now scratch stores w ** 2
+#         if len(scratch.flat) == 0:
+#             # no data
+#             continue
+#
+#         dig = numpy.digitize(scratch.flat, w2edges)
+#
+#         # take the sum of w
+#         scratch **= 0.5
+#         # the singular plane is down weighted by 0.5
+#         scratch[singular] *= 0.5
+#
+#         wsum1 = numpy.bincount(dig, weights=scratch.flat, minlength=wout.size + 2)[1: -1]
+#         wsum += wsum1
+#
+#         # take the sum of weights
+#         scratch[...] = 1.0
+#         # the singular plane is down weighted by 0.5
+#         scratch[singular] = 0.5
+#
+#         N1 = numpy.bincount(dig, weights=scratch.flat, minlength=wout.size + 2)[1: -1]
+#         N += N1
+#
+#         # take the sum of power
+#         scratch[...] = c1[row].real * c2[row].real + c1[row].imag * c2[row].imag
+#         # the singular plane is down weighted by 0.5
+#         scratch[singular] *= 0.5
+#
+#         P1 = numpy.bincount(dig, weights=scratch.flat, minlength=wout.size + 2)[1: -1]
+#         P += P1
+#
+#     wsum = pm.comm.allreduce(wsum, MPI.SUM)
+#     P = pm.comm.allreduce(P, MPI.SUM)
+#     N = pm.comm.allreduce(N, MPI.SUM)
+#
+#     psout[:] = P / N
+#     wout[:] = wsum / N
+#     Nout[:] = N
+#
+#     kout = wout * pm.Nmesh / pm.BoxSize
+#     psout *= (pm.BoxSize) ** 3
+#
+#     psout -= shotnoise
+#
+#     return kout, psout, Nout, wedges*pm.Nmesh/pm.BoxSize
     
-    wedges = numpy.linspace(0, numpy.pi, wout.size + 1, endpoint=True)
-    wedges += binshift * wedges[1]
-
-    w2edges = wedges ** 2
-
-    wsum = numpy.zeros(len(psout))
-    P = numpy.zeros(len(psout))
-    N = numpy.zeros(len(psout))
-    for row in range(len(pm.w[0])):
-        # pickup the singular plane that is single counted (r2c transform)
-        singular = pm.w[2][-1] == 0
-
-        scratch = numpy.float64(pm.w[0][row] ** 2)
-        for wi in pm.w[1:]:
-            scratch = scratch + wi[0] ** 2
-
-        # now scratch stores w ** 2
-        if len(scratch.flat) == 0:
-            # no data
-            continue
-
-        dig = numpy.digitize(scratch.flat, w2edges)
-
-        # take the sum of w
-        scratch **= 0.5
-        # the singular plane is down weighted by 0.5
-        scratch[singular] *= 0.5
-
-        wsum1 = numpy.bincount(dig, weights=scratch.flat, minlength=wout.size + 2)[1: -1]
-        wsum += wsum1
-
-        # take the sum of weights
-        scratch[...] = 1.0
-        # the singular plane is down weighted by 0.5
-        scratch[singular] = 0.5
-
-        N1 = numpy.bincount(dig, weights=scratch.flat, minlength=wout.size + 2)[1: -1]
-        N += N1
-
-        # take the sum of power
-        scratch[...] = c1[row].real * c2[row].real + c1[row].imag * c2[row].imag
-        # the singular plane is down weighted by 0.5
-        scratch[singular] *= 0.5
-
-        P1 = numpy.bincount(dig, weights=scratch.flat, minlength=wout.size + 2)[1: -1]
-        P += P1
-
-    wsum = pm.comm.allreduce(wsum, MPI.SUM)
-    P = pm.comm.allreduce(P, MPI.SUM)
-    N = pm.comm.allreduce(N, MPI.SUM)
-
-    psout[:] = P / N 
-    wout[:] = wsum / N
-    Nout[:] = N
-
-    kout = wout * pm.Nmesh / pm.BoxSize
-    psout *= (pm.BoxSize) ** 3
-
-    psout -= shotnoise
-
-    return kout, psout, Nout, wedges*pm.Nmesh/pm.BoxSize
-    
-def measure2Dpower(pm, c1, c2, binshift=0.0, shotnoise=0.0, Nmu=5):
+def measure2Dpower(pm, c1, c2, Nmu, binshift=0.0, shotnoise=0.0, los='z'):
     """ Measure 2D power spectrum P(k,mu) from density field painted on pm 
 
         The power spectrum is measured in bins of k and mu. The k bins extend 
         from 0 to the Nyquist (Nmesh / 2), with the units consistent with 
         the units of the BoxSize. The mu range extends from 0 to 1.
+        
 
         Parameters
         ----------
@@ -116,6 +117,10 @@ def measure2Dpower(pm, c1, c2, binshift=0.0, shotnoise=0.0, Nmu=5):
         c2: array_like
             the complex fourier space field to measure power from.
 
+        Nmu : int
+            The number of mu bins to use when binning in the power spectrum, 
+            default is 5
+        
         binshift   : float
             shift the center of bins by this fraction if a bin width
 
@@ -123,9 +128,10 @@ def measure2Dpower(pm, c1, c2, binshift=0.0, shotnoise=0.0, Nmu=5):
             remove the shot noise contribution from the final power spectrum
             The shot noise is (pm.BoxSize) ** 3 / Ntot, where Ntot is the total
             number of particles.
-
-        Nmu : int
-            The number of mu bins to use when binning in the power spectrum. 
+        
+        los : str
+            the line-of-sight direction, which the angle `mu` is defined with
+            respect to. Default is `z` (last column)
             
     """
     Nfreq = pm.Nmesh//2
@@ -150,15 +156,17 @@ def measure2Dpower(pm, c1, c2, binshift=0.0, shotnoise=0.0, Nmu=5):
     Psum = numpy.zeros(ndims[0]*ndims[1])
     Nsum = numpy.zeros(ndims[0]*ndims[1])
     
+    # los index
+    los_index = 'xyz'.index(los)
+    
     for row in range(len(pm.w[0])):
         # pickup the singular plane that is single counted (r2c transform)
         singular = pm.w[2][-1] == 0
 
+        # now scratch stores w ** 2
         scratch = numpy.float64(pm.w[0][row] ** 2)
         for wi in pm.w[1:]:
             scratch = scratch + wi[0] ** 2
-
-        # now scratch stores w ** 2
 
         if len(scratch.flat) == 0:
             # no data
@@ -171,9 +179,12 @@ def measure2Dpower(pm, c1, c2, binshift=0.0, shotnoise=0.0, Nmu=5):
     
         # store mu
         with numpy.errstate(invalid='ignore'):
-            mu = abs(pm.w[-1][0]/scratch)
+            if los_index == 0:
+                mu = abs(pm.w[los_index][row]/scratch)
+            else:
+                mu = abs(pm.w[los_index][0]/scratch)
         dig_mu = numpy.digitize(mu.flat, muedges)
-    
+        
         # make the multi-index
         multi_index = numpy.ravel_multi_index([dig_w, dig_mu], ndims)
     
@@ -216,11 +227,9 @@ def measure2Dpower(pm, c1, c2, binshift=0.0, shotnoise=0.0, Nmu=5):
         N[:] = Nsum.reshape(ndims)[1:-1, 1:-1]
 
     # measure the raw power spectrum, nothing is removed.
-
     kout = wmean * pm.Nmesh / pm.BoxSize
     kedges = wedges * pm.Nmesh / pm.BoxSize
     power *= (pm.BoxSize) ** 3
-
     power -= shotnoise
 
     return kout, mumean, power, N, [kedges, muedges]

--- a/nbodykit/plugins/Power1DStorage.py
+++ b/nbodykit/plugins/Power1DStorage.py
@@ -8,7 +8,7 @@ class Power1DStorage(PowerSpectrumStorage):
     def register(kls):
         PowerSpectrumStorage.add_storage_klass(kls)
 
-    def write(self, data):
+    def write(self, data, **meta):
         with self.open() as ff:
             numpy.savetxt(ff, zip(*data), '%0.7g')
             ff.flush()

--- a/nbodykit/plugins/Power2DStorage.py
+++ b/nbodykit/plugins/Power2DStorage.py
@@ -8,7 +8,7 @@ class Power2DStorage(PowerSpectrumStorage):
     def register(kls):
         PowerSpectrumStorage.add_storage_klass(kls)
 
-    def write(self, data, **metadata):
+    def write(self, data, **meta):
         """
         Write a 2D power spectrum as plain text.
                 
@@ -16,7 +16,7 @@ class Power2DStorage(PowerSpectrumStorage):
         ----------
         data : dict
             the data columns to write out
-        metadata : dict
+        meta : dict
             any additional metadata to write out at the end of the file
         """
         keys = data.keys()
@@ -54,9 +54,9 @@ class Power2DStorage(PowerSpectrumStorage):
                 ff.write(header+values)
             
             # lastly, write out metadata, if any
-            if len(metadata):
-                ff.write("metadata %d\n" %len(metadata))
-                for k,v in metadata.iteritems():
+            if len(meta):
+                ff.write("metadata %d\n" %len(meta))
+                for k,v in meta.iteritems():
                     ff.write("%s %s %s\n" %(k, str(v), type(v).__name__))
             
             ff.flush()

--- a/nbodykit/plugins/__init__.py
+++ b/nbodykit/plugins/__init__.py
@@ -132,7 +132,7 @@ class PowerSpectrumStorage:
             if ff is not sys.stdout:
                 ff.close()
 
-    def write(self, data):
+    def write(self, data, **meta):
         return NotImplemented
             
 #------------------------------------------------------------------------------          


### PR DESCRIPTION
* los option specifies which direction mu is defined wrt
* only commented out old measurepower function now -- Yu,
feel free to delete once you've made edits