### PR TITLE
Update MBIIDMO.py

### DIFF
--- a/contrib/MBIIDMO.py
+++ b/contrib/MBIIDMO.py
@@ -77,7 +77,7 @@ class PainterPlugin(InputPainter):
         if self.rsd is not None:
             dir = 'xyz'.index(self.rsd)
             data['position'][:, dir] += data['velocity'][:, dir]
-            pos['position'][:, dir] %= ns.BoxSize # enforce periodic boundary conditions
+            data['position'][:, dir] %= ns.BoxSize # enforce periodic boundary conditions
 
         layout = pm.decompose(data['position'])
         tpos = layout.exchange(data['position'])


### PR DESCRIPTION
fixed typo 
File "power.py", line 167, in <module>
    main()
  File "power.py", line 102, in main
    Ntot1 = ns.inputs[0].paint(ns, pm)
  File "contrib/MBIIDMO.py", line 80, in paint
    pos['position'][:, dir] %= ns.BoxSize # enforce periodic boundary conditions
IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices