### PR TITLE
vectorizing ``transfer`` and ``painter`` keywords to compute_3d_power

### DIFF
--- a/nbodykit/datasource/Pandas.py
+++ b/nbodykit/datasource/Pandas.py
@@ -95,7 +95,8 @@ class PandasDataSource(DataSource):
         try:
             import pandas as pd
         except:
-            raise ImportError("pandas must be installed to use PandasPlainTextDataSource")
+            name = self.__class__.__name__
+            raise ImportError("pandas must be installed to use %s" %name)
                 
         if self.ftype == 'auto':
             if self.path.endswith('.hdf5'):


### PR DESCRIPTION
* new behavior won't change any existing code
* use case is using different painters / transfer chains for 1st or 2nd field in cross-correlations (which I need for the density-velocity correlators) 