### PR TITLE
fixes output bug for P(k,mu) + improvements

### DIFF
--- a/nbodykit/files.py
+++ b/nbodykit/files.py
@@ -295,7 +295,7 @@ class HaloFile(object):
 def ReadPower2DPlainText(filename):
     """
     Reads the plain text storage of a 2D power spectrum measurement,
-    as output by the `nbodykit.plugins.Power2DStorage` plugin
+    as output by the `nbodykit.plugins.Measurement2DStorage` plugin
     
     Returns
     -------
@@ -318,11 +318,19 @@ def ReadPower2DPlainText(filename):
         
         lines = ff.readlines()
         data = numpy.array([map(float, line.split()) for line in lines[:N]])
-        data = data.reshape((Nk, Nmu, -1))
+        data = data.reshape((Nk, Nmu, -1)) #reshape properly to (Nk, Nmu)
                         
-        # reshape properly to (Nk, Nmu)
-        for i, name in enumerate(columns):        
-            toret[name] = data[...,i]
+        # store as return dict, making complex arrays from real/imag parts
+        i = 0
+        while i < len(columns):
+            name = columns[i]
+            nextname = columns[i+1] if i < len(columns)-1 else None
+            if nextname and not name.endswith('_real') and nextname.endswith('_imag'):
+                toret[name] = data[...,i] + 1j*data[...,i+1]       
+                i += 2
+            else:
+                toret[name] = data[...,i]
+                i += 1
         
         # read the edges for k and mu bins
         edges = []
@@ -353,7 +361,7 @@ def ReadPower2DPlainText(filename):
 def ReadPower1DPlainText(filename):
     """
     Reads the plain text storage of a 1D power spectrum measurement,
-    as output by the `nbodykit.plugins.Power1DStorage` plugin.
+    as output by the `nbodykit.plugins.Measurement1DStorage` plugin.
     
     Notes
     -----

--- a/nbodykit/files.py
+++ b/nbodykit/files.py
@@ -325,8 +325,9 @@ def ReadPower2DPlainText(filename):
         while i < len(columns):
             name = columns[i]
             nextname = columns[i+1] if i < len(columns)-1 else None
-            if nextname and not name.endswith('_real') and nextname.endswith('_imag'):
-                toret[name] = data[...,i] + 1j*data[...,i+1]       
+            if nextname and name.endswith('_real') and nextname.endswith('_imag'):
+                name = name.split('_real')[0]
+                toret[name] = data[...,i] + 1j*data[...,i+1]
                 i += 2
             else:
                 toret[name] = data[...,i]

--- a/nbodykit/plugins/Measurement1DStorage.py
+++ b/nbodykit/plugins/Measurement1DStorage.py
@@ -32,6 +32,9 @@ class Measurement1DStorage(MeasurementStorage):
             Any additional metadata to write to file, specified as keyword 
             arguments
         """
+        if len(cols) != len(data):
+            raise ValueError("size mismatch between column names and data arrays")
+            
         data = list(data)
         with self.open() as ff:
             
@@ -42,7 +45,9 @@ class Measurement1DStorage(MeasurementStorage):
             for i in range(len(data)-1, -1, -1):
                 if numpy.iscomplexobj(data[i]):
                     data.insert(i+1, data[i].imag)
+                    cols.insert(i+1, cols[i]+'_imag')
                     data[i] = data[i].real
+                    cols[i] = cols[i] + '_real'
                     
             # write out the 1D data arrays
             numpy.savetxt(ff, numpy.vstack(data).T, '%0.7g')

--- a/nbodykit/plugins/Measurement2DStorage.py
+++ b/nbodykit/plugins/Measurement2DStorage.py
@@ -23,6 +23,9 @@ class Measurement2DStorage(MeasurementStorage):
         meta : dict
             any additional metadata to write out at the end of the file
         """
+        if len(cols) != len(data):
+            raise ValueError("size mismatch between column names and data arrays")
+            
         data = list(data)
         with self.open() as ff:
             
@@ -37,7 +40,9 @@ class Measurement2DStorage(MeasurementStorage):
             for i in range(len(data)-1, -1, -1):
                 if numpy.iscomplexobj(data[i]):
                     data.insert(i+1, data[i].imag)
+                    cols.insert(i+1, cols[i]+'_imag')
                     data[i] = data[i].real
+                    cols[i] = cols[i] + '_real'
             
             # write out flattened columns
             numpy.savetxt(ff, numpy.dstack(data).reshape((-1, len(cols))), '%0.7g')

--- a/nbodykit/plugins/Measurement2DStorage.py
+++ b/nbodykit/plugins/Measurement2DStorage.py
@@ -32,10 +32,7 @@ class Measurement2DStorage(MeasurementStorage):
             # write number of mu and k bins first
             N1, N2 = data[0].shape
             ff.write(("%d %d\n" %(N1, N2)).encode())
-            
-            # write out column names
-            ff.write((" ".join(cols) + "\n").encode())
-            
+                        
             # split any complex fields into separate columns
             for i in range(len(data)-1, -1, -1):
                 if numpy.iscomplexobj(data[i]):
@@ -43,7 +40,10 @@ class Measurement2DStorage(MeasurementStorage):
                     cols.insert(i+1, cols[i]+'_imag')
                     data[i] = data[i].real
                     cols[i] = cols[i] + '_real'
-            
+                    
+            # write out column names
+            ff.write((" ".join(cols) + "\n").encode())
+
             # write out flattened columns
             numpy.savetxt(ff, numpy.dstack(data).reshape((-1, len(cols))), '%0.7g')
             


### PR DESCRIPTION
the current logic for output: 

* output complex power as successive columns
* update column names in header by appending "_real" and "_imag"
* the 2D reader looks for "_real"/"_imag" pairs in column names and reconstructs
the complex output, which it returns
* the 1D reader just does a numpy.loadtxt, so it returns an array with real/imag as successive columns