### PR TITLE
introduces TransferFunction plugins, YAML file parsing in power.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
 install:
     - conda create --yes -n test python=$TRAVIS_PYTHON_VERSION
     - source activate test
-    - conda install --yes numpy=$NUMPY_VERSION nose cython mpi4py h5py pandas scipy pytables yaml
+    - conda install --yes numpy=$NUMPY_VERSION nose cython mpi4py h5py pandas scipy pytables pyyaml
     - if [ $TRAVIS_PYTHON_VERSION == 2.6 ]; then conda install --yes argparse; fi
     - pip install --pre pfft-python kdcount mpsort pmesh sharedmem --no-deps
     - pip install --pre -r requirements.txt .

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
 install:
     - conda create --yes -n test python=$TRAVIS_PYTHON_VERSION
     - source activate test
-    - conda install --yes numpy=$NUMPY_VERSION nose cython mpi4py h5py pandas scipy pytables
+    - conda install --yes numpy=$NUMPY_VERSION nose cython mpi4py h5py pandas scipy pytables yaml
     - if [ $TRAVIS_PYTHON_VERSION == 2.6 ]; then conda install --yes argparse; fi
     - pip install --pre pfft-python kdcount mpsort pmesh sharedmem --no-deps
     - pip install --pre -r requirements.txt .

--- a/bin/power.py
+++ b/bin/power.py
@@ -11,39 +11,165 @@ logging.basicConfig(level=logging.DEBUG,
 logger = logging.getLogger('power.py')
               
 from nbodykit import measurestats
-from nbodykit.extensionpoints import DataSource
-from nbodykit.extensionpoints import Painter
+from nbodykit.extensionpoints import DataSource, Painter, Transfer
 from nbodykit.extensionpoints import MeasurementStorage
-from nbodykit.plugins import ArgumentParser, ListPluginsAction
-from argparse import Action
+from nbodykit.extensionpoints import plugin_isinstance
 
+from nbodykit.plugins import ArgumentParser, ListPluginsAction, load
+from argparse import Action, SUPPRESS
 from pmesh.particlemesh import ParticleMesh
-from pmesh.transfer import TransferFunction
 
-class InputAction(Action):
-    def __init__(self, option_strings, dest, 
-        nargs=None, const=None, default=None, type=None, 
-        choices=None, required=False, help=None, metavar=None):
-        Action.__init__(self, option_strings, dest,
-                nargs, const, default, type, choices, required, help, metavar)
+def construct_fields(input_fields, X=None):
+    """
+    Construct a list holding 1 or 2 tuples of (DataSource, Painter, Transfer).
+    """
+    # load plugin paths
+    if X is not None:
+        if isinstance(X, str):
+            load(X)
+        elif isinstance(X, list):
+            for path in X: load(path)
+    
+    fields = []
+    i = 0
+    N = len(input_fields)
+    
+    while i < N:
+        
+        # start with a default option for (DataSource, Painter, Transfer)
+        field = [None, Painter.create("DefaultPainter"), []]
+        
+        # should be a DataSource here, or break
+        if plugin_isinstance(input_fields[i], DataSource):
+            
+            # set data source
+            field[0] = DataSource.create(input_fields[i])
+            
+            # loop until out of values or another DataSource found
+            i += 1
+            while i < N and not plugin_isinstance(input_fields[i], DataSource):
+                s = input_fields[i]
+                
+                # set Painter
+                if plugin_isinstance(s, Painter):
+                    field[1] = Painter.create(s)
+                # add one Transfer
+                elif plugin_isinstance(s, Transfer):
+                    field[2].append(Transfer.create(s))
+                # add list of Transfers
+                elif isinstance(s, list):
+                    field[2] += [Transfer.create(x) for x in s]
+                else:
+                    raise ValueError("failure to parse line `%s` for `fields` key" %str(s))                    
+                i += 1
+            fields.append(tuple(field))
+        else: # failure
+            raise ValueError("failure to parse `fields`")
 
-    def __call__(self, parser, namespace, values, option_string=None):
-        fields = []
-        default_painter = Painter.create("DefaultPainter")
-        for string in values:
-            try:
-                datasource = DataSource.create(string)
-                fields.append((datasource, default_painter))
-            except KeyError: # FIXME: define a proper way to test if the string
-                             # is a datasource or redo this entire mechanism
-                datasource, painter = fields.pop()
-                painter = Painter.create(string)
-                fields.append((datasource, painter))
-        namespace.fields = fields
+    return fields
+    
+h = """
+    mode: 
+        help: 1d or 2d
+        choices: [1d, 2d]
+    Nmesh:
+        help: size of calculation mesh, recommend 2 * Ngrid
+    output:
+        help: write power to this file. set as `-` for stdout'
+    fields:
+        help: Input data sources and painters. 
+               Use --list-painter and --list-datasource to see a list of painters and data sources.
+    los: 
+        help: the line-of-sight direction, which the angle `mu` is defined with respect to
+        choices: [x, y, z]
+        default: z
+        required: False
+    Nmu: 
+        help: the number of mu bins to use; if `mode = 1d`, then `Nmu` is set to 1
+        default: 5
+        required: False
+    dk: 
+        help: the spacing of k bins to use; if not provided, the fundamental mode of the box is used
+    kmin:
+        help: the edge of the first bin to use; default is 0
+        default: 0.
+        required: False
+    poles:
+        help: if specified, compute these multipoles from P(k,mu), saving to `pole_output`
+        default: []
+        required: False
+    pole_output: 
+        help: the name of the output file for multipoles
+        required: False
+    correlation:
+        help: compute the correlation function instead of power spectrum
+        default : False
+        required: False
+    """
 
-#--------------------------------------------------
-# setup the parser
-#--------------------------------------------------
+def ReadConfigFile(parser_string):
+    import yaml
+    
+    class ConfigFileAction(Action):
+        info = yaml.load(parser_string)
+            
+        def __call__(self, parser, namespace, values, option_string=None):
+            
+            # set defaults
+            for k in self.info:
+                setattr(namespace, k, self.info[k].get('default', None))
+        
+            # read the yaml config file
+            config = yaml.load(open(values, 'r'))
+            
+            # set the fields attribute
+            namespace.fields = construct_fields(config.pop('fields'), X=config.pop('X', None))
+            
+            for k in config:
+                v = config[k]
+                if 'choices' in self.info[k]:
+                    if config[k] not in self.info[k]['choices']:
+                        args = (k, config[k], ", ".join(["'%s'" %a for a in self.info[k]['choices']]))
+                        raise ValueError("argument %s: invalid choice '%s' (choose from %s)" %args)
+                setattr(namespace, k, config[k])
+                
+        @classmethod
+        def format_help(cls):
+            positional = []
+            optional = []
+            for k in cls.info:
+                s =  "  %-20s %s" %(k, cls.info[k]['help'])
+                if cls.info[k].get('required', True):
+                    positional.append(s)
+                else:
+                    optional.append(s)
+            
+            positional = "\n".join(positional)
+            optional = "\n".join(optional)
+            help_str = "positional arguments:\n%s\n\noptional arguments:\n%s\n" %(positional, optional)
+
+            class ConfigFileHelp(Action):
+                def __init__(self,
+                             option_strings,
+                             dest=SUPPRESS,
+                             default=SUPPRESS,
+                             help=None):
+                    Action.__init__(self, 
+                        option_strings=option_strings,
+                        dest=dest,
+                        default=default,
+                        nargs=0,
+                        help=help)
+                           
+                def __call__(self, parser, namespace, values, option_string=None):
+                    parser.exit(0, help_str)
+            return ConfigFileHelp
+            
+    return ConfigFileAction
+
+
+        
+        
 def initialize_parser(**kwargs):
     """
     Initialize the command-line parser for ``power.py``, 
@@ -71,51 +197,24 @@ def initialize_parser(**kwargs):
          """,
             **kwargs
          )
-
-    # add the positional arguments
-    parser.add_argument("mode", choices=["2d", "1d"]) 
-    parser.add_argument("Nmesh", type=int, help='size of calculation mesh, recommend 2 * Ngrid')
-    parser.add_argument("output", help='write power to this file. set as `-` for stdout') 
-
-    # add the input field types
-    h = "one or two input fields, specified as:\n\n"
-    parser.add_argument("fields", nargs="+", 
-            action=InputAction,
-            help="Input data sources and painters. Use --list-painter and --list-datasource to see a list of painters and data sources.", 
-            metavar="DataSource [Painter] [DataSource [Painter]]")
-
-    parser.add_argument("--list-painter", action=ListPluginsAction(Painter))
-    parser.add_argument("--list-datasource", action=ListPluginsAction(DataSource))
-
-    # add the optional arguments
-    parser.add_argument("--los", choices="xyz", default='z',
-            help="the line-of-sight direction, which the angle `mu` is defined with respect to")
-    parser.add_argument("--Nmu", type=int, default=5,
-            help='the number of mu bins to use; if `mode = 1d`, then `Nmu` is set to 1' )
-    parser.add_argument("--dk", type=float,
-            help='the spacing of k bins to use; if not provided, the fundamental mode of the box is used')
-    parser.add_argument("--kmin", type=float, default=0,
-            help='the edge of the first bin to use; default is 0')
-    parser.add_argument('-q', '--quiet', help="silence the logging output",
-            action="store_const", dest="log_level", const=logging.ERROR, default=logging.DEBUG)
-    parser.add_argument('--poles', type=lambda s: [int(i) for i in s.split()], default=[],
-            help='if specified, compute these multipoles from P(k,mu), saving to `pole_output`')
-    parser.add_argument('--pole_output', type=str, help='the name of the output file for multipoles')
-
-    parser.add_argument("--correlation", action='store_true', default=False,
-        help='Calculate correlation function instead of power spectrum.')
     
+    # add the input field types
+    read_config = ReadConfigFile(h)
+    parser.add_argument("config", type=str, action=read_config, help="the configuration file; use --config-help for format")
+    parser.add_argument("--config-help", action=read_config.format_help())
+
+    parser.add_argument('-q', '--quiet', help="silence the logging output",  
+            action="store_const", dest="log_level", const=logging.ERROR, default=logging.DEBUG)
+    
+
+    parser.add_argument("--list-datasource", action=ListPluginsAction(DataSource))
+    parser.add_argument("--list-painter", action=ListPluginsAction(Painter))
+    parser.add_argument("--list-transfer", action=ListPluginsAction(Transfer))
+
     return parser
 
-#--------------------------------------------------
-# computation tools
-#--------------------------------------------------
-def AnisotropicCIC(comm, complex, w):
-    for wi in w:
-        tmp = (1 - 2. / 3 * numpy.sin(0.5 * wi) ** 2) ** 0.5
-        complex[:] /= tmp
 
-def compute_power(ns, comm=None, transfer=None):
+def compute_power(ns, comm=None):
     """
     Compute the power spectrum. Given a `Namespace`, this is the function,
     that computes and saves the power spectrum. It does all the work.
@@ -124,30 +223,12 @@ def compute_power(ns, comm=None, transfer=None):
     ----------
     ns : argparse.Namespace
         the parser namespace corresponding to the ``initialize_parser``
-        functions
+        function
     comm : MPI.Communicator
         the communicator to pass to the ``ParticleMesh`` object
-    transfer : list, optional
-        list of transfer functions to apply that will be
-        passed to ``compute_3d_power``. If `None`, then
-        the default chain ``TransferFunction.NormalizeDC``, 
-        ``TransferFunction.RemoveDC``, and ``AnisotropicCIC``
-        will be applied
-    """    
+    """
     rank = comm.rank if comm is not None else MPI.COMM_WORLD.rank
-    
-    # handle default measurement keywords
-    measure_kw = {'comm':comm, 'log_level':ns.log_level}
-    
-    # transfer chain
-    default_chain = [TransferFunction.NormalizeDC, TransferFunction.RemoveDC, AnisotropicCIC]
-    measure_kw.setdefault('transfer', default_chain)
-    if transfer is not None:
-        measure_kw['transfer'] = transfer
-    
-    # set logging level
     logger.setLevel(ns.log_level)
-    
     if rank == 0: logger.info('importing done')
 
     # setup the particle mesh object, taking BoxSize from the painters
@@ -155,15 +236,12 @@ def compute_power(ns, comm=None, transfer=None):
 
     # only need one mu bin if 1d case is requested
     if ns.mode == "1d": ns.Nmu = 1
-
-    # binning keywords
-    binning_kw = {'poles':ns.poles, 'los':ns.los}
     
     # correlation function
     if ns.correlation:
 
         # measure
-        y3d, N1, N2 = measurestats.compute_3d_corr(ns.fields, pm, **measure_kw)
+        y3d, N1, N2 = measurestats.compute_3d_corr(ns.fields, pm, comm=comm, log_level=ns.log_level)
         x3d = pm.x
                 
         # make the bin edges
@@ -171,7 +249,7 @@ def compute_power(ns, comm=None, transfer=None):
         xedges = numpy.arange(0, pm.BoxSize[0] + dx * 0.5, dx)
         
         # correlation needs all modes
-        binning_kw['symmetric'] = False
+        symmetric = False
         
         # col names
         x_str, y_str = 'r', 'corr'
@@ -180,7 +258,7 @@ def compute_power(ns, comm=None, transfer=None):
     else:
         
         # measure
-        y3d, N1, N2 = measurestats.compute_3d_power(ns.fields, pm, **measure_kw)
+        y3d, N1, N2 = measurestats.compute_3d_power(ns.fields, pm, comm=comm, log_level=ns.log_level)
         x3d = pm.k
         
         # binning in k out to the minimum nyquist frequency 
@@ -189,7 +267,7 @@ def compute_power(ns, comm=None, transfer=None):
         xedges = numpy.arange(ns.kmin, numpy.pi*pm.Nmesh/pm.BoxSize.min() + dx/2, dx)
         
         # power spectrum doesnt need negative z wavenumbers
-        binning_kw['symmetric'] = True
+        symmetric = True
         
         # col names
         x_str, y_str = 'k', 'power'
@@ -197,7 +275,9 @@ def compute_power(ns, comm=None, transfer=None):
     # project on to the desired basis
     muedges = numpy.linspace(0, 1, ns.Nmu+1, endpoint=True)
     edges = [xedges, muedges]
-    result, pole_result = measurestats.project_to_basis(pm.comm, x3d, y3d, edges, **binning_kw)
+    result, pole_result = measurestats.project_to_basis(pm.comm, x3d, y3d, edges, 
+                                                        poles=ns.poles, los=ns.los, 
+                                                        symmetric=symmetric)
 
     # now output    
     if ns.mode == "1d":
@@ -234,9 +314,6 @@ def compute_power(ns, comm=None, transfer=None):
             
             
 def main():
-    """
-    The main function to initialize the parser and do the work
-    """
     # parse
     ns = initialize_parser().parse_args()
         

--- a/bin/power.py
+++ b/bin/power.py
@@ -36,12 +36,11 @@ class InputAction(Action):
                 fields.append((datasource, default_painter))
             except KeyError: # FIXME: define a proper way to test if the string
                              # is a datasource or redo this entire mechanism
-                painter = Painter.create(string)
                 datasource, painter = fields.pop()
+                painter = Painter.create(string)
                 fields.append((datasource, painter))
         namespace.fields = fields
-        
-        
+
 #--------------------------------------------------
 # setup the parser
 #--------------------------------------------------

--- a/examples/power/run.sh
+++ b/examples/power/run.sh
@@ -3,5 +3,5 @@ cd $DIR
 [ -d ../output ] || mkdir ../output
 for fn in *.params; do
     echo testing $fn ...
-    mpirun -n 2 python ../../bin/power.py @$fn || exit
+    mpirun -n 2 python ../../bin/power.py $fn || exit
 done

--- a/examples/power/test_cross_power.params
+++ b/examples/power/test_cross_power.params
@@ -1,5 +1,8 @@
-1d
-256
-../output/test_cross_power.txt
-TPMSnapshot:../data/snp00100_1.0000.bin:1380
-FOFGroups:../output/fof00100_ll0.200_1.0000.hdf5:1380:10.0
+mode: 1d
+Nmesh: 256
+output: ../output/test_cross_power.txt
+fields:
+    - TPMSnapshot:../data/snp00100_1.0000.bin:1380
+    - [NormalizeDC, RemoveDC, AnisotropicCIC]
+    - FOFGroups:../output/fof00100_ll0.200_1.0000.hdf5:1380:10.0
+    - [NormalizeDC, RemoveDC, AnisotropicCIC]

--- a/examples/power/test_fofgroups.param
+++ b/examples/power/test_fofgroups.param
@@ -1,8 +1,8 @@
-2d      # 1d or 2d
-256     # size of mesh
-../output/power_2d_fofgroups.dat  # output
+mode: 2d      # 1d or 2d
+Nmesh: 256     # size of mesh
+output: ../output/power_2d_fofgroups.dat  # output
 
 # here are the input files
-FOFGroups:../output/fof00100_ll0.200_1.0000.hdf5:1380:10.0 \
-:-rsd=z \
-:-select= Rank < 1000
+fields:
+    - FOFGroups:../output/fof00100_ll0.200_1.0000.hdf5:1380:10.0:-rsd=z:-select= Rank < 1000
+    - [NormalizeDC, RemoveDC, AnisotropicCIC]

--- a/examples/power/test_mwhite_halo.params
+++ b/examples/power/test_mwhite_halo.params
@@ -1,5 +1,7 @@
-2d
-256
-../output/test_power_2d_mwhite_halo_test.dat
-MWhiteHaloFile:../data/mwhite_halo.fofp:1380.:-rsd=z
--X=../../contrib/MWhiteHaloFile.py
+mode: 2d
+Nmesh: 256
+output: ../output/test_power_2d_mwhite_halo_test.dat
+fields:
+    - MWhiteHaloFile:../data/mwhite_halo.fofp:1380.:-rsd=z
+    - [NormalizeDC, RemoveDC, AnisotropicCIC]
+X: ../../contrib/MWhiteHaloFile.py

--- a/examples/power/test_pandas_hdf.params
+++ b/examples/power/test_pandas_hdf.params
@@ -1,10 +1,8 @@
-2d      # 1d or 2d
-256     # size of mesh
-../output/power_2d_pandas_hdf.dat  # output
+mode: 2d      # 1d or 2d
+Nmesh: 256     # size of mesh
+output: ../output/power_2d_pandas_hdf.dat  # output
 
 # here are the input files
-Pandas:../data/pandas_data.hdf5:data:1380. \
-:-poscols=x y z \
-:-velcols=vx vy vz \
-:-posf=1380.0:-velf=1380.0 \
-:-rsd=z 
+fields:
+    - Pandas:../data/pandas_data.hdf5:data:1380.:-poscols=x y z:-velcols=vx vy vz:-posf=1380.0:-velf=1380.0:-rsd=z
+    - [NormalizeDC, RemoveDC, AnisotropicCIC]

--- a/examples/power/test_pandas_text.params
+++ b/examples/power/test_pandas_text.params
@@ -1,4 +1,6 @@
-2d
-256
-../output/power_2d_pandas_plaintext_test.dat
-Pandas:../data/plaintext.txt:x y z z_redshift is_sat N_sat collided resolved:1380:-poscols=x y z_redshift:-ftype=text
+mode: 2d
+Nmesh: 256
+output: ../output/power_2d_pandas_plaintext_test.dat
+fields:
+    - Pandas:../data/plaintext.txt:x y z z_redshift is_sat N_sat collided resolved:1380:-poscols=x y z_redshift:-ftype=text
+    - [NormalizeDC, RemoveDC, AnisotropicCIC]

--- a/examples/power/test_plaintext.params
+++ b/examples/power/test_plaintext.params
@@ -1,4 +1,7 @@
-2d
-256
-../output/power_2d_plaintext_test.dat
-PlainText:../data/plaintext.txt:x y z z_redshift is_sat N_sat collided resolved:1380:-poscols=x y z_redshift
+mode: 2d
+Nmesh: 256
+output: ../output/power_2d_plaintext_test.dat
+fields:
+    - PlainText:../data/plaintext.txt:x y z z_redshift is_sat N_sat collided resolved:1380:-poscols=x y z_redshift
+    - DefaultPainter
+    - [NormalizeDC, RemoveDC, AnisotropicCIC]

--- a/examples/power/test_tpmsnapshot_1d.params
+++ b/examples/power/test_tpmsnapshot_1d.params
@@ -1,4 +1,6 @@
-1d
-256
-../output/test_power_tpmsnapshot_1d.txt
-TPMSnapshot:../data/snp00100_1.0000.bin:1380
+mode: 1d
+Nmesh: 256
+output: ../output/test_power_tpmsnapshot_1d.txt
+fields:
+    - TPMSnapshot:../data/snp00100_1.0000.bin:1380
+    - [NormalizeDC, RemoveDC, AnisotropicCIC]

--- a/examples/power/test_tpmsnapshot_1d_corr.params
+++ b/examples/power/test_tpmsnapshot_1d_corr.params
@@ -1,5 +1,7 @@
---correlation
-1d
-256
-../output/test_corr_tpmsnapshot_1d.txt
-TPMSnapshot:../data/snp00100_1.0000.bin:1380
+correlation: True
+mode: 1d
+Nmesh: 256
+output: ../output/test_corr_tpmsnapshot_1d.txt
+fields:
+    - TPMSnapshot:../data/snp00100_1.0000.bin:1380
+    - [NormalizeDC, RemoveDC, AnisotropicCIC]

--- a/examples/power/test_tpmsnapshot_2d.params
+++ b/examples/power/test_tpmsnapshot_2d.params
@@ -1,4 +1,5 @@
-2d
-256
-../output/test_power_tpmsnapshot_2d.txt
-TPMSnapshot:../data/snp00100_1.0000.bin:1380
+mode: 2d
+Nmesh: 256
+output: ../output/test_power_tpmsnapshot_2d.txt
+fields:
+    - TPMSnapshot:../data/snp00100_1.0000.bin:1380

--- a/nbodykit/__init__.py
+++ b/nbodykit/__init__.py
@@ -2,7 +2,7 @@ from nbodykit.plugins import load
 import os.path
 path = os.path.abspath(os.path.dirname(__file__))
 
-builtins = ['datasource/', 'storage/', 'painter/']
+builtins = ['datasource/', 'storage/', 'painter/', 'transfer/']
 
 for plugin in builtins:
     load(os.path.join(path, 'plugins', plugin))

--- a/nbodykit/extensionpoints.py
+++ b/nbodykit/extensionpoints.py
@@ -131,6 +131,40 @@ from nbodykit.plugins import HelpFormatterColon
 from argparse import ArgumentParser
 
 @ExtensionPoint
+class Transfer:
+    """
+    Mount point for plugins which apply a k-space transfer function
+    to the Fourier transfrom of a datasource field
+    
+    Plugins implementing this reference should provide the following 
+    attributes:
+
+    plugin_name : str
+        class attribute giving the name of the subparser which 
+        defines the necessary command line arguments for the plugin
+    
+    register : classmethod
+        A class method taking no arguments that adds a subparser
+        and the necessary command line arguments for the plugin
+    
+    __call__ : method
+        function that will apply the transfer function to the complex array
+    """
+    def __call__(self, pm, complex):
+        """ 
+        Apply the transfer function to the complex field
+        
+        Parameters
+        ----------
+        pm : ParticleMesh
+            the particle mesh object which holds possibly useful
+            information, i.e, `w` or `k` arrays
+        complex : array_like
+            the complex array to apply the transfer to
+        """
+        raise NotImplementedError
+
+@ExtensionPoint
 class DataSource:
     """
     Mount point for plugins which refer to the reading of input files 
@@ -295,3 +329,18 @@ class MeasurementStorage:
 
     def write(self, cols, data, **meta):
         return NotImplemented
+        
+__all__ = ['DataSource', 'Painter', 'Transfer', 'MeasurementStorage']
+
+def plugin_isinstance(string, extensionpt):
+    """
+    Return `True` if the string representation of an extension point
+    is an instance of the extension point class `extensionpt`
+    """
+    if not hasattr(extensionpt, 'plugins'):
+        raise TypeError("please specify a valid extension point as the second argument")
+        
+    if not isinstance(string, str):
+        return False
+    return string.split(":")[0] in extensionpt.plugins.keys()
+    

--- a/nbodykit/extensionpoints.py
+++ b/nbodykit/extensionpoints.py
@@ -60,23 +60,21 @@ class PluginMount(type):
         else:
             if not hasattr(cls, 'plugin_name'):
                 raise RuntimeError("Plugin class must carry a plugin_name.")
-
-            if cls.plugin_name in cls.plugins:
-                raise RuntimeError("Plugin class %s already registered with %s"
-                    % (cls.plugin_name, str(type(cls))))
-
-            # add a commandline argument parser that parsers the ':' seperated
-            # commandlines.
-            cls.parser = ArgumentParser(cls.plugin_name, 
-                    usage=None, add_help=False, 
-                    formatter_class=HelpFormatterColon)
-
-            # track names of classes
-            cls.plugins[cls.plugin_name] = cls
             
-            # try to call register class method
-            if hasattr(cls, 'register'):
-                cls.register()
+            # register, if this plugin isn't yet
+            if cls.plugin_name not in cls.plugins:
+                # add a commandline argument parser that parsers the ':' seperated
+                # commandlines.
+                cls.parser = ArgumentParser(cls.plugin_name, 
+                        usage=None, add_help=False, 
+                        formatter_class=HelpFormatterColon)
+
+                # track names of classes
+                cls.plugins[cls.plugin_name] = cls
+            
+                # try to call register class method
+                if hasattr(cls, 'register'):
+                    cls.register()
 
     def create(kls, string): 
         """ Instantiate a plugin from this extension point,

--- a/nbodykit/plugins/transfer/TransferFunction.py
+++ b/nbodykit/plugins/transfer/TransferFunction.py
@@ -1,0 +1,71 @@
+from nbodykit.extensionpoints import Transfer
+import numpy
+
+class AnisotropicCIC(Transfer):
+    """
+    Divide by a kernel in Fourier space to account for
+    the convolution of the gridded quantity with the 
+    cloud-in-cell window function in configuration space
+    """
+    plugin_name = "AnisotropicCIC"
+
+    @classmethod
+    def register(kls):
+        pass
+
+    def __call__(self, pm, complex):
+        for wi in pm.w:
+            tmp = (1 - 2. / 3 * numpy.sin(0.5 * wi) ** 2) ** 0.5
+            complex[:] /= tmp
+            
+            
+class NormalizeDC(Transfer):
+    """
+    Removes the DC amplitude in Fourier space, which effectively
+    divides by the mean in configuration space
+    """
+    plugin_name = "NormalizeDC"
+
+    @classmethod
+    def register(kls):
+        pass
+
+    def __call__(self, pm, complex):
+        ind = []
+        value = 0.
+        found = True
+        for wi in pm.w:
+            if (wi != 0).all():
+                found = False
+                break
+            ind.append((wi == 0).nonzero()[0][0])
+        if found:
+            ind = tuple(ind)
+            value = numpy.abs(complex[ind])
+        value = pm.comm.allreduce(value)
+        complex[:] /= value
+        
+class RemoveDC(Transfer):
+    """
+    Remove the DC amplitude, which sets the mean of the 
+    field in configuration space to zero
+    """
+    plugin_name = "RemoveDC"
+
+    @classmethod
+    def register(kls):
+        pass
+
+    def __call__(self, pm, complex):
+        ind = []
+        for wi in pm.w:
+            if (wi != 0).all():
+                return
+            ind.append((wi == 0).nonzero()[0][0])
+        ind = tuple(ind)
+        complex[ind] = 0.
+            
+
+
+        
+            

--- a/nbodykit/utils/taskmanager.py
+++ b/nbodykit/utils/taskmanager.py
@@ -8,30 +8,30 @@ logger = logging.getLogger('taskmanager')
 #------------------------------------------------------------------------------
 # tools
 #------------------------------------------------------------------------------        
-def split_ranks(N_ranks, avg):
+def split_ranks(N_ranks, N_chunks):
     """
-    Divide the ranks into chunks, trying to specify `avg` ranks per chunk,
-    plus any remainder. This first removes the master (0) rank
+    Divide the ranks into N chunks, removing the master (0) rank
     
     Parameters
     ----------
     N_ranks : int
         the total number of ranks available
-    avg : int
-        the desired number of ranks per chunk
+    N_chunks : int
+        the number of chunks to split the ranks into
     """
     seq = range(1, N_ranks)
-    N = len(seq)
+    avg = int((N_ranks-1) // N_chunks)
+    remainder = (N_ranks-1) % N_chunks
 
     start = 0
     end = avg
-    i = 0
-    while start < N:
-        if end > N: end = N
+    for i in range(N_chunks):
+        if remainder:
+            end += 1
+            remainder -= 1
         yield i, seq[start:end]
         start = end
         end += avg
-        i += 1
         
 def enum(*sequential, **named):
     enums = dict(zip(sequential, range(len(sequential))), **named)
@@ -150,8 +150,9 @@ class TaskManager(object):
                 'output/pkmu_output_box{box}.dat'"""
         parser.add_argument('param_file', type=str, help=h)
     
-        h = "the desired number of workers for each task force"
-        parser.add_argument('workers_per', type=int, help=h)
+        h = """the number of independent nodes that will run jobs in parallel; 
+                must be less than nprocs"""
+        parser.add_argument('nodes', type=int, help=h)
     
         h =  """given a string of the format ``key tasks``, split the string and then
                 try to parse the ``tasks``, by first trying to evaluate it, and then
@@ -159,8 +160,8 @@ class TaskManager(object):
         
                 The general use cases are: 
         
-                1) "-i box: range(2)" -> key = `box`, tasks = `[0, 1]`
-                2) "-i box: [A, B, C,]" -> key = `box`, tasks = `['A', 'B', 'C']`
+                1) "box: range(2)" -> key = `box`, tasks = `[0, 1]`
+                2) "box: [A, B, C]" -> key = `box`, tasks = `['A', 'B', 'C']`
                 
                 If multiple options passed with `-i` flag, then the total tasks to 
                 perform will be the product of the tasks lists passed"""
@@ -196,38 +197,26 @@ class TaskManager(object):
         
         return args    
     
-    def _initialize_worker_comm(self):
+    def _initialize_pool_comm(self):
         """
-        Internal function that initializes the `MPI.Intracomm` used by each
-        group of workers. This will be passed to the task function and used 
+        Internal function that initializes the `MPI.Intracomm` used by the 
+        pool of workers. This will be passed to the task function and used 
         in task computation
         """
-        self.worker_comm = None
-        self.num_groups = 0
-        
-        nranks_min = int(0.5*self.config.workers_per)
+        # split the ranks
+        self.pool_comm = None
+        chain_ranks = []
         color = 0
-        rank_count = 0
-        for i, ranks in split_ranks(self.size, self.config.workers_per):
-            
-            if self.rank in ranks:
-                
-                # only used this group of workers if it has at least 1/2 the 
-                # desired amount
-                if len(ranks) >= nranks_min:
-                    color = i+1
-                else:
-                    color = None
-            
-            rank_count += len(ranks)
-            if len(ranks) >= nranks_min:
-                self.num_groups += 1
+        worker_count = 0
+        for i, ranks in split_ranks(self.size, self.config.nodes):
+            chain_ranks.append(ranks[0])
+            if self.rank in ranks: color = i+1
+            worker_count += len(ranks)
         
-        if rank_count != self.size-1:
-            args = (rank_count, self.size-1)
-            raise RuntimeError("mismatch between rank count (%d) and spawned worker processes (%d)" %args)
-        if color is not None:
-            self.worker_comm = self.comm.Split(color, 0)
+        if worker_count != self.size-1:
+            args = (worker_count, self.size-1)
+            raise RuntimeError("mismatch between worker count (%d) and spawned worker processes (%d)" %args)
+        self.pool_comm = self.comm.Split(color, 0)
         
     def run_all(self):
         """
@@ -240,13 +229,13 @@ class TaskManager(object):
         tags = enum('READY', 'DONE', 'EXIT', 'START')
         status = MPI.Status()
     
-        # crash if we don't have enough cpus
-        if self.size <= self.config.workers_per:
-            args = (self.size, self.config.workers_per+1)
-            raise ValueError("only have %d ranks; need at least %d" %args)    
+        # crash if we only have one process or one node
+        if self.size <= self.config.nodes:
+            args = (self.size, self.config.nodes+1, self.config.nodes)
+            raise ValueError("only have %d ranks; need at least %d to use the desired %d nodes" %args)    
       
         # make the pool comm
-        self._initialize_worker_comm()
+        self._initialize_pool_comm()
     
         # the tasks provided on the command line
         tasks = self.config.tasks
@@ -257,12 +246,12 @@ class TaskManager(object):
         
             # initialize
             task_index = 0
-            num_groups = self.num_groups
-            closed_groups = 0
+            num_workers = self.config.nodes
+            closed_workers = 0
         
             # loop until all workers have finished with no more tasks
-            logger.info("master starting with %d worker groups with %d total tasks" %(num_groups, num_tasks))
-            while closed_groups < num_groups:
+            logger.info("master starting with %d node workers with %d total tasks" %(num_workers, num_tasks))
+            while closed_workers < num_workers:
                 data = self.comm.recv(source=MPI.ANY_SOURCE, tag=MPI.ANY_TAG, status=status)
                 source = status.Get_source()
                 tag = status.Get_tag()
@@ -279,39 +268,37 @@ class TaskManager(object):
                     results = data
                     logger.debug("received result from worker %d" %source)
                 elif tag == tags.EXIT:
-                    closed_groups += 1
-                    logger.debug("worker %d has exited, closed workers = %d" %(source, closed_groups))
+                    closed_workers += 1
+                    logger.debug("worker %d has exited, closed workers = %d" %(source, closed_workers))
     
         # worker processes wait and execute single jobs
-        # but leftover processes dont do anything here
-        elif self.worker_comm is not None:
-            
-            if self.worker_comm.rank == 0:
-                args = (self.rank, MPI.Get_processor_name(), self.worker_comm.size)
+        else:
+            if self.pool_comm.rank == 0:
+                args = (self.rank, MPI.Get_processor_name(), self.pool_comm.size)
                 logger.info("pool master rank is %d on %s with %d processes available" %args)
             while True:
                 task = -1
                 tag = -1
         
                 # have the master rank of the pool ask for task and then broadcast
-                if self.worker_comm.rank == 0:
+                if self.pool_comm.rank == 0:
                     self.comm.send(None, dest=0, tag=tags.READY)
                     task = self.comm.recv(source=0, tag=MPI.ANY_TAG, status=status)
                     tag = status.Get_tag()
-                task = self.worker_comm.bcast(task)
-                tag = self.worker_comm.bcast(tag)
+                task = self.pool_comm.bcast(task)
+                tag = self.pool_comm.bcast(tag)
         
                 # do the work here
                 if tag == tags.START:
                     result = self.run_single_task(task, tasks.index(task), param_file)
-                    self.worker_comm.Barrier() # wait for everyone
-                    if self.worker_comm.rank == 0:
+                    self.pool_comm.Barrier() # wait for everyone
+                    if self.pool_comm.rank == 0:
                         self.comm.send(result, dest=0, tag=tags.DONE) # done this task
                 elif tag == tags.EXIT:
                     break
 
-            self.worker_comm.Barrier()
-            if self.worker_comm.rank == 0:
+            self.pool_comm.Barrier()
+            if self.pool_comm.rank == 0:
                 self.comm.send(None, dest=0, tag=tags.EXIT) # exiting
     
         # free and exit
@@ -319,7 +306,7 @@ class TaskManager(object):
         self.comm.Barrier()
         if self.rank == 0:
             logger.info("master is finished; terminating")
-            self.worker_comm.Free()
+            self.pool_comm.Free()
             
             
     def run_single_task(self, task, itask, param_file):
@@ -337,7 +324,7 @@ class TaskManager(object):
             the parameter file for the task function, read as a string, 
             which will be string formatted
         """
-        pool_rank = self.worker_comm.rank
+        pool_rank = self.pool_comm.rank
 
         # if you are the pool's root, write out the temporary parameter file
         temp_name = None
@@ -365,13 +352,13 @@ class TaskManager(object):
                 ff.write(param_file.format(**valid))
         
         # bcast the file name to all in the worker pool
-        temp_name = self.worker_comm.bcast(temp_name, root=0)
+        temp_name = self.pool_comm.bcast(temp_name, root=0)
 
         # parse the file with updated parameters
         ns = self.task_parser.parse_args(['%s' %temp_name])
 
         # run the task function using the comm for this worker pool
-        self.task_function(ns, comm=self.worker_comm)
+        self.task_function(ns, comm=self.pool_comm)
 
         # remove temporary files
         if pool_rank == 0:

--- a/nbodykit/utils/taskmanager.py
+++ b/nbodykit/utils/taskmanager.py
@@ -349,7 +349,7 @@ class TaskManager(object):
         temp_name = self.pool_comm.bcast(temp_name, root=0)
 
         # parse the file with updated parameters
-        ns = self.task_parser.parse_args(['@%s' %temp_name])
+        ns = self.task_parser.parse_args(['%s' %temp_name])
 
         # run the task function using the comm for this worker pool
         self.task_function(ns, comm=self.pool_comm)

--- a/nbodykit/utils/taskmanager.py
+++ b/nbodykit/utils/taskmanager.py
@@ -283,7 +283,9 @@ class TaskManager(object):
                     logger.debug("worker %d has exited, closed workers = %d" %(source, closed_groups))
     
         # worker processes wait and execute single jobs
-        else:
+        # but leftover processes dont do anything here
+        elif self.worker_comm is not None:
+            
             if self.worker_comm.rank == 0:
                 args = (self.rank, MPI.Get_processor_name(), self.worker_comm.size)
                 logger.info("pool master rank is %d on %s with %d processes available" %args)

--- a/nbodykit/utils/taskmanager.py
+++ b/nbodykit/utils/taskmanager.py
@@ -219,13 +219,13 @@ class TaskManager(object):
                 else:
                     color = None
             
-            worker_count += len(ranks)
+            rank_count += len(ranks)
             if len(ranks) >= nranks_min:
                 self.num_groups += 1
         
-        if worker_count != self.size-1:
-            args = (worker_count, self.size-1)
-            raise RuntimeError("mismatch between worker count (%d) and spawned worker processes (%d)" %args)
+        if rank_count != self.size-1:
+            args = (rank_count, self.size-1)
+            raise RuntimeError("mismatch between rank count (%d) and spawned worker processes (%d)" %args)
         if color is not None:
             self.worker_comm = self.comm.Split(color, 0)
         


### PR DESCRIPTION
* power examples have been updated to use YAML syntax -- CI won't succeed until latest pmesh change updated but works on laptop 
* I've implemented a basic first pass at doing "help", "defaults", "choices" in the YAML parser in power.py -- maybe @rainwoodman can take a look and spice it up a bit

A few things to note: 
   * in the ``construct_fields`` function which makes the tuples of (DataSource, Painter, Transfer), I also had to pass in any `X` options and load them, so that the X options can be specified in the config file (in addition to the command line)
   * Maybe we want to make the default Transfer chain [NormalizeDC, RemoveDC, AnisotropicCIC]. It seems to be the the desired chain in nearly all of the cases...