### PR TITLE
fixes Ntot bug in default DataSource.read

### DIFF
--- a/nbodykit/extensionpoints.py
+++ b/nbodykit/extensionpoints.py
@@ -196,12 +196,11 @@ class DataSource:
         if comm.rank == 0:
             data = self.readall(columns)    
             shape_and_dtype = [(d.shape, d.dtype) for d in data]
-            Ntot = len(data)
+            Ntot = len(data[0])
         else:
             shape_and_dtype = None
             Ntot = None
         shape_and_dtype = comm.bcast(shape_and_dtype)
-
         stat['Ntot'] = comm.bcast(Ntot)
 
         if comm.rank != 0:


### PR DESCRIPTION
* Ntot was set to the number of columns, not number of rows