### PR TITLE
config yaml reading done explicitly by Algorithm function

### DIFF
--- a/bin/power.py
+++ b/bin/power.py
@@ -241,7 +241,7 @@ def initialize_compatible_parser():
 
     parser.add_argument("mode", choices=["2d", "1d"]) 
     parser.add_argument("Nmesh", type=int, help='size of calculation mesh, recommend 2 * Ngrid')
-    parser.add_argument("output", help='write power to this file. set as `-` for stdout') 
+    parser.add_argument("-o", dest='output', required=True, help='write power to this file. set as `-` for stdout') 
 
     # add the input field types
     h = "one or two input fields, specified as:\n\n"
@@ -267,7 +267,7 @@ def initialize_compatible_parser():
         help='Calculate correlation function instead of power spectrum.')
 
     def error(message): 
-        raise ValueError(x)
+        raise ValueError(message)
     parser.error = error
     return parser
 

--- a/examples/power/run.sh
+++ b/examples/power/run.sh
@@ -7,11 +7,11 @@ for fn in *.params; do
     then
         mpirun -n 2 python ../../bin/nbkit.py FFTCorrelation -c $fn || exit
     else
-        mpirun -n 2 python ../../bin/nbkit.py PeriodicPower -c $fn || exit
+        mpirun -n 2 python ../../bin/nbkit.py FFTPower -c $fn || exit
     fi
 done
 
 for fn in *.argparse; do
     echo testing $fn ...
-    mpirun -n 2 python ../../bin/nbkit.py PeriodicPower @$fn || exit
+    mpirun -n 2 python ../../bin/nbkit.py FFTPower @$fn || exit
 done

--- a/nbodykit/extensionpoints.py
+++ b/nbodykit/extensionpoints.py
@@ -19,7 +19,7 @@ import numpy
 # a plugin instance will be created for a MPI communicator.
 from mpi4py import MPI
 
-from nbodykit.plugins import HelpFormatterColon
+from nbodykit.plugins import HelpFormatterColon, load
 from argparse import Namespace, SUPPRESS, ArgumentParser
 
 import sys
@@ -447,7 +447,86 @@ class MeasurementStorage:
 #------------------------------------------------------------------------------
 # plugin classes implementing `Algorithm`        
 #------------------------------------------------------------------------------
+def ReadConfigFile(parser, config_file):
+    """
+    Return an `argparse.Action` subclass that reads parameters from a file
+    using YAML syntax
+    
+    This is designed to be used with `plugins.ArgumentParser` and be
+    called via the command-line with a `-c` or `--config` option
+    
+    The action uses the underlying ArgumentParser to:
+        * infer default values
+        * check if parameter values are consistent with `choices`
+        * infer the `type` of each parameter
+        * check if any required parameters are missing
+        
+    Parameters
+    ----------
+    types : keywords
+        the keys should be names of parameters and the values are functions
+        that cast the parameter values appropriately. the function should
+        take one argument, which is the value read from file
+    """
+    import yaml
+    
+    # make a new namespace
+    ns, unknown = Namespace(), Namespace()
 
+    # read the yaml config file
+    config = yaml.load(open(config_file, 'r'))
+    
+    # first search for plugins
+    plugins = []
+    if 'X' in config:
+        plugins = config['X']
+        if isinstance(plugins, str):
+            plugins = [plugins]
+        for plugin in plugins: load(plugin)
+        unknown.X = plugins 
+        config.pop('X')
+
+    
+    # set defaults, check required and choices
+    argnames = set([a.dest for a in parser._actions])
+    missing = []
+    types = {}
+    for a in parser._actions:
+        
+        # set the default, if not suppressed
+        if a.default != SUPPRESS:
+            setattr(ns, a.dest, a.default)
+            
+        # check for choices
+        if a.dest in config: 
+            if a.choices is not None:
+                if config[a.dest] not in a.choices:
+                    args = (a.dest, config[a.dest], ", ".join(["'%s'" %x for x in a.choices]))
+                    raise ValueError("argument %s: invalid choice '%s' (choose from %s)" %args)
+            if a.dest not in types and a.type is not None:
+                types[a.dest] = a.type
+        else:        
+            # track missing        
+            if a.required: missing.append(a.dest)
+                
+    # raise error if missing
+    if len(missing):
+        missing = "(%s)" % ", ".join("'%s'" %k for k in missing)
+        args = (parser.format_usage(), parser.prog, missing)
+        raise ValueError("%s\n\n%s: too few arguments, missing: %s" %args)
+                
+    # set the values, casting if available
+    for k in config:
+        v = config[k]
+        if k in argnames:
+            if k in types: v = types[k](v)
+            setattr(ns, k, v)
+        else:
+            setattr(unknown, k, v)
+    
+    return ns, unknown
+    
+    
 @ExtensionPoint(algorithms)
 class Algorithm:
     """
@@ -468,12 +547,24 @@ class Algorithm:
     
     __call__ : method
         function that will apply the transfer function to the complex array
-    """
+    """        
     def run(self):
         raise NotImplementedError
     
     def save(self, *args, **kwargs):
         raise NotImplementedError
+    
+    @classmethod
+    def parse_known_yaml(kls, name, config_file):
+        """
+        Parse the known (and unknown) attributes from a YAML, where `known`
+        arguments must be part of the Algorithm.parser instance
+        """
+        # get the class for this algorithm name
+        klass = kls.plugins[name]
+        
+        # get the namespace from the config file
+        return ReadConfigFile(klass.parser, config_file)
         
 
 __all__ = ['DataSource', 'Painter', 'Transfer', 'MeasurementStorage', 'Algorithm']

--- a/nbodykit/extensionpoints.py
+++ b/nbodykit/extensionpoints.py
@@ -19,8 +19,8 @@ import numpy
 # a plugin instance will be created for a MPI communicator.
 from mpi4py import MPI
 
-from nbodykit.plugins import HelpFormatterColon, ArgumentParser
-from argparse import Namespace, SUPPRESS
+from nbodykit.plugins import HelpFormatterColon
+from argparse import Namespace, SUPPRESS, ArgumentParser
 
 import sys
 import contextlib
@@ -120,7 +120,6 @@ class PluginMount(type):
                 cls.parser = ArgumentParser(cls.plugin_name, 
                                             usage=None, 
                                             add_help=False, 
-                                            args=(),
                                             formatter_class=HelpFormatterColon)
 
                 # track names of classes

--- a/nbodykit/plugins.py
+++ b/nbodykit/plugins.py
@@ -203,7 +203,10 @@ class ArgumentParser(BaseArgumentParser):
         If `config` is a option, return the namespace created from reading
         the YAML file -- otherwise, use the default behavior
         """
-        result = BaseArgumentParser.parse_known_args(self, args, self.ns)
+        if args is None:
+            import sys
+            args = sys.argv[1:]
+        result = BaseArgumentParser.parse_known_args(self, args)
         
         # if parsing failed, result is None
         if result is None:

--- a/nbodykit/plugins.py
+++ b/nbodykit/plugins.py
@@ -42,111 +42,6 @@ from argparse import Action, SUPPRESS
 import re
 import sys
 
-def ReadConfigFile(**types):
-    """
-    Return an `argparse.Action` subclass that reads parameters from a file
-    using YAML syntax
-    
-    This is designed to be used with `plugins.ArgumentParser` and be
-    called via the command-line with a `-c` or `--config` option
-    
-    The action uses the underlying ArgumentParser to:
-        * infer default values
-        * check if parameter values are consistent with `choices`
-        * infer the `type` of each parameter
-        * check if any required parameters are missing
-        
-    Parameters
-    ----------
-    types : keywords
-        the keys should be names of parameters and the values are functions
-        that cast the parameter values appropriately. the function should
-        take one argument, which is the value read from file
-    """
-    import yaml
-    
-    class ConfigFileAction(Action):
-            
-        def __call__(self, parser, namespace, values, option_string=None):
-            
-            # make a new namespace
-            ns = Namespace()
-        
-            # read the yaml config file
-            config = yaml.load(open(values, 'r'))
-            
-            # set defaults, check required and choices
-            argnames = set([a.dest for a in parser._actions])
-            missing = []
-            for a in parser._actions:
-                
-                # set the default, if not suppressed
-                if a.default != SUPPRESS:
-                    setattr(ns, a.dest, a.default)
-                    
-                # check for choices
-                if a.dest in config: 
-                    if a.choices is not None:
-                        if config[a.dest] not in a.choices:
-                            args = (a.dest, config[a.dest], ", ".join(["'%s'" %x for x in a.choices]))
-                            raise ValueError("argument %s: invalid choice '%s' (choose from %s)" %args)
-                    if a.dest not in types and a.type is not None:
-                        types[a.dest] = a.type
-                else:        
-                    # track missing        
-                    if a.required: missing.append(a.dest)
-            
-            # raise error if missing
-            if len(missing):
-                missing = "(%s)" % ", ".join("'%s'" %k for k in missing)
-                args = (parser.format_usage(), parser.prog, missing)
-                raise ValueError("%s\n\n%s: too few arguments, missing: %s" %args)
-                        
-            # set the values, casting if available
-            for k in config:
-                if k in argnames:
-                    v = config[k]
-                    if k in types: v = types[k](v)
-                    setattr(ns, k, v)
-            
-            # config attr of main namespace is new namespace
-            setattr(namespace, self.dest, ns)
-                                                    
-    return ConfigFileAction
-    
-def ConfigPreparser(*keys):
-    class PreparseConfigAction(Action):
-        """
-        Open a config file, read parameters assuming a YAML format, and
-        load any plugins specified via the `X` key
-        """
-        def __call__(self, parser, namespace, values, option_string=None):
-            import yaml
-            
-            # read the yaml config file
-            config = yaml.load(open(values, 'r'))
-            
-            # search for plugins
-            plugins = []
-            if 'X' in config:
-                plugins = config['X']
-                if isinstance(plugins, str):
-                    plugins = [plugins]
-                for plugin in plugins: load(plugin)
-        
-            # save for debugging purposes   
-            if namespace.X is not None: 
-                namespace.X += plugins
-            else:
-                namespace.X = plugins
-            
-            # also grab any other specified keys
-            for key in keys:
-                if key in config:
-                    setattr(namespace, key, config[key])
-                    
-    return PreparseConfigAction
-
 class ArgumentParser(BaseArgumentParser):
     """ 
     An argument parser that loads plugins before dropping to
@@ -156,7 +51,7 @@ class ArgumentParser(BaseArgumentParser):
     option or set from a YAML config file, which is
     passed via `-c` or `--config`. 
     """
-    def __init__(self, name, preparse_from_config=[], *largs, **kwargs):
+    def __init__(self, name, *largs, **kwargs):
 
         # initialize the preparser
         kwargs['formatter_class'] = RawTextHelpFormatter
@@ -167,45 +62,8 @@ class ArgumentParser(BaseArgumentParser):
 
         # parse -X on cmdline or search config file for -X options
         self.add_argument("-X", type=load, action="append")
-        self.add_argument('-c', '--config', action=ConfigPreparser(*preparse_from_config))
-
-        # track error messages
-        self.error_messages = []
-        
-    def error(self, message):
-        """
-        If `config` is an option, ignore all exceptions so we can read 
-        options from file, otherwise, use the default `error` behavior
-        """
-        self.error_messages.append(message)
-        
-    def parse_known_args(self, args=None, namespace=None):
-        """
-        If `config` is a option, return the namespace created from reading
-        the YAML file -- otherwise, use the default behavior
-        """
-        if args is None:
-            import sys
-            args = sys.argv[1:]
-        result = BaseArgumentParser.parse_known_args(self, args)
-        
-        # if parsing failed, result is None
-        if result is None:
-            if len(self.error_messages):
-                BaseArgumentParser.error(self, self.error_messages[0])
-        
-        ns, args = result
-        no_config = 'config' not in ns or ns.config is None
-        
-        # if no config file, check errors
-        if no_config and len(self.error_messages):
-            BaseArgumentParser.error(self, self.error_messages[0])
-        
-        # okay, no errors -- return either config or cmd-line namespace
-        if no_config:
-            return ns, args
-        else:
-            return ns.config, args
+        self.add_argument('-c', '--config', type=str, 
+                            help='the name of the file to read parameters from, using YAML syntax')
 
     # override file reading option to treat each line as 
     # an argument and ignore comments. Can put option + value on same line

--- a/nbodykit/plugins.py
+++ b/nbodykit/plugins.py
@@ -161,32 +161,13 @@ class ArgumentParser(BaseArgumentParser):
         # initialize the preparser
         kwargs['formatter_class'] = RawTextHelpFormatter
         kwargs['fromfile_prefix_chars']="@"
-        args = kwargs.pop('args', None)    
-        preparser = BaseArgumentParser(add_help=False, 
-                    fromfile_prefix_chars=kwargs['fromfile_prefix_chars'])
-                    
-        # parse -X on cmdline or search config file for -X options
-        preparser.add_argument("-X", type=load, action="append")
-        preparser.add_argument('-c', '--config', action=ConfigPreparser(*preparse_from_config))
 
-        # process the plugins
-        preparser.exit = lambda a, b: None
-        preparser._read_args_from_files     = ArgumentParser._read_args_from_files.__get__(preparser)         
-        preparser._yield_args_from_files    = ArgumentParser._yield_args_from_files.__get__(preparser)         
-        preparser.convert_args_file_to_args = ArgumentParser.convert_args_file_to_args.__get__(preparser)         
-        ns, unknown = preparser.parse_known_args(args)
-        
-        # only keep the preparsed values
-        ns = vars(ns)
-        self.ns = Namespace()
-        for k in preparse_from_config:
-            if k in ns: setattr(self.ns, k, ns[k])
-    
         # do the base initialization
         BaseArgumentParser.__init__(self, name, *largs, **kwargs)
 
-        # for clarity add this automatically
-        self.add_argument("-X", action='append', help='path of additional plugins to be loaded')
+        # parse -X on cmdline or search config file for -X options
+        self.add_argument("-X", type=load, action="append")
+        self.add_argument('-c', '--config', action=ConfigPreparser(*preparse_from_config))
 
         # track error messages
         self.error_messages = []


### PR DESCRIPTION
new API for handling config for algorithm

-- `config` now an option of the plugin ArgumentParser, which is designed to be
only run by nbkit.py
-- `config` parsing explicitly handled by a function of Algorithm
--  better definitions of an Action and Type for Fields in FFTPower
-- renames PeriodicPower to FFTPower

this closes #130 