### PR TITLE
DataSource cache function; TracerCatalog clean up

### DIFF
--- a/contrib/BOSSChallengeMock.py
+++ b/contrib/BOSSChallengeMock.py
@@ -96,35 +96,56 @@ class BOSSChallengeBoxADataSource(BOSSChallengeMockDataSource):
     qperp = 0.998753592
     qpar = 0.9975277944
     
+    def __init__(self, path, BoxSize, scaled=False):
+        super(BOSSChallengeBoxADataSource, self).__init__(path, BoxSize, scaled)
+    
 class BOSSChallengeBoxBDataSource(BOSSChallengeMockDataSource):
     plugin_name = 'BOSSChallengeBoxB'
     qperp = 0.998753592
     qpar = 0.9975277944
+    
+    def __init__(self, path, BoxSize, scaled=False):
+        super(BOSSChallengeBoxBDataSource, self).__init__(path, BoxSize, scaled)
     
 class BOSSChallengeBoxCDataSource(BOSSChallengeMockDataSource):
     plugin_name = 'BOSSChallengeBoxC'
     qperp = 0.9875682111
     qpar = 0.9751013789
     
+    def __init__(self, path, BoxSize, scaled=False):
+        super(BOSSChallengeBoxCDataSource, self).__init__(path, BoxSize, scaled)
+    
 class BOSSChallengeBoxDDataSource(BOSSChallengeMockDataSource):
     plugin_name = 'BOSSChallengeBoxD'
     qperp = 0.9916978595
     qpar = 0.9834483344
+    
+    def __init__(self, path, BoxSize, scaled=False):
+        super(BOSSChallengeBoxDDataSource, self).__init__(path, BoxSize, scaled)
     
 class BOSSChallengeBoxEDataSource(BOSSChallengeMockDataSource):
     plugin_name = 'BOSSChallengeBoxE'
     qperp = 0.9916978595
     qpar = 0.9834483344
     
+    def __init__(self, path, BoxSize, scaled=False):
+        super(BOSSChallengeBoxEDataSource, self).__init__(path, BoxSize, scaled)
+    
 class BOSSChallengeBoxFDataSource(BOSSChallengeMockDataSource):
     plugin_name = 'BOSSChallengeBoxF'
     qperp = 0.998753592
     qpar = 0.9975277944
     
+    def __init__(self, path, BoxSize, scaled=False):
+        super(BOSSChallengeBoxFDataSource, self).__init__(path, BoxSize, scaled)
+    
 class BOSSChallengeBoxGDataSource(BOSSChallengeMockDataSource):
     plugin_name = 'BOSSChallengeBoxG'
     qperp = 0.998753592
     qpar = 0.9975277944
+    
+    def __init__(self, path, BoxSize, scaled=False):
+        super(BOSSChallengeBoxGDataSource, self).__init__(path, BoxSize, scaled)
 
 
 class BOSSChallengeNSeriesDataSource(DataSource):

--- a/nbodykit/extensionpoints.py
+++ b/nbodykit/extensionpoints.py
@@ -13,14 +13,18 @@
 
     1. add a class decorator @ExtensionPoint
 """
-import numpy
 from nbodykit.utils.config import autoassign, ConstructorSchema, ReadConfigFile
 from nbodykit.distributedarray import ScatterArray
+
+import numpy
 from argparse import Namespace
+from functools import wraps
+from inspect import isgeneratorfunction
 
 # MPI will be required because
 # a plugin instance will be created for a MPI communicator.
 from mpi4py import MPI
+
 
 algorithms  = Namespace()
 datasources = Namespace()
@@ -329,6 +333,51 @@ class DataSource:
         default behavior is to use Rank 0 to read in the full data
         and yield an empty data. 
     """
+    @staticmethod
+    def cached(f):
+        """
+        Decorator to cache return values of `DataSource.read` or 
+        `DataSource.simple_read` function calls
+        
+        This is designed such that the user can decorate any
+        DataSource `read` calls in any DataSource Plugin
+        """
+        cache = {}
+        isgenerator = isgeneratorfunction(f) # simple_read or read
+        
+        @wraps(f)
+        def wrapped(self, columns, **kwargs):
+            
+            # only respects full at the moment
+            full = kwargs.get('full', None)
+            if set(kwargs) not in [{"full"}, set()]:
+                raise ValueError("DataSource cache only respects `full` keyword; others provided")
+            
+            # find out which columns are in cache
+            missing = [(c, full) for c in columns if (c,full) not in cache]
+            if len(missing):
+                cols = [m[0] for m in missing]
+                result = f(self, cols, **kwargs)
+                
+                # if generator returned, unpack it into list and arrange by column
+                if isgenerator:
+                    result = list(zip(*result))
+                # cache each column result
+                for i, key in enumerate(missing):
+                    cache[key] = result[i]
+            
+            # return
+            toret = [cache[(col,full)] for col in columns]
+            if isgenerator:
+                # can't zip if the iteration size isn't even
+                # this shouldn't happen, but if it does, just call full function
+                if not all(len(d) == len(toret[0]) for d in toret):
+                    return f(self, columns, **kwargs)
+                toret = zip(*toret) # re-zip results from a generator
+            return toret
+        wrapped.cache = cache
+        return wrapped
+        
     @staticmethod
     def BoxSizeParser(value):
         """

--- a/nbodykit/extensionpoints.py
+++ b/nbodykit/extensionpoints.py
@@ -18,7 +18,7 @@ from nbodykit.distributedarray import ScatterArray
 
 import numpy
 from argparse import Namespace
-from functools import wraps
+import functools
 from inspect import isgeneratorfunction
 
 # MPI will be required because
@@ -297,6 +297,45 @@ class Transfer:
         """
         raise NotImplementedError
 
+def memoized(f):
+    """
+    Decorator to cache return values of `DataSource.read`
+    
+    This is designed such that the user can decorate any
+    DataSource `read` calls in any DataSource Plugin
+    """
+    cache = {}
+
+    @functools.wraps(f)
+    def wrapped(*args, **kwargs):
+        columns = args[-1]
+        
+        # only respects full at the moment
+        full = kwargs.get('full', None)
+        if set(kwargs) not in [{"full"}, set()]:
+            raise ValueError("DataSource cache only respects `full` keyword; others were provided")
+
+        # find out which columns are in cache
+        missing = [(c, full) for c in columns if (c,full) not in cache]
+        if len(missing):
+            cols = [m[0] for m in missing]
+            newargs = list(args); newargs[-1] = cols
+            result = f(*newargs, **kwargs) # this is a generator
+
+            # generator returned, so unpack it into list and arrange by column
+            result = list(zip(*result))
+            # cache each column result
+            for i, key in enumerate(missing):
+                cache[key] = result[i]
+
+        # return
+        toret = [cache[(col,full)] for col in columns]
+        return zip(*toret) # re-zip results from the generator
+        
+    wrapped.cache = cache
+    return wrapped
+
+
 @ExtensionPoint(datasources)
 class DataSource:
     """
@@ -332,52 +371,7 @@ class DataSource:
         same units as position), in chunks as an iterator. The
         default behavior is to use Rank 0 to read in the full data
         and yield an empty data. 
-    """
-    @staticmethod
-    def cached(f):
-        """
-        Decorator to cache return values of `DataSource.read` or 
-        `DataSource.simple_read` function calls
-        
-        This is designed such that the user can decorate any
-        DataSource `read` calls in any DataSource Plugin
-        """
-        cache = {}
-        isgenerator = isgeneratorfunction(f) # simple_read or read
-        
-        @wraps(f)
-        def wrapped(self, columns, **kwargs):
-            
-            # only respects full at the moment
-            full = kwargs.get('full', None)
-            if set(kwargs) not in [{"full"}, set()]:
-                raise ValueError("DataSource cache only respects `full` keyword; others provided")
-            
-            # find out which columns are in cache
-            missing = [(c, full) for c in columns if (c,full) not in cache]
-            if len(missing):
-                cols = [m[0] for m in missing]
-                result = f(self, cols, **kwargs)
-                
-                # if generator returned, unpack it into list and arrange by column
-                if isgenerator:
-                    result = list(zip(*result))
-                # cache each column result
-                for i, key in enumerate(missing):
-                    cache[key] = result[i]
-            
-            # return
-            toret = [cache[(col,full)] for col in columns]
-            if isgenerator:
-                # can't zip if the iteration size isn't even
-                # this shouldn't happen, but if it does, just call full function
-                if not all(len(d) == len(toret[0]) for d in toret):
-                    return f(self, columns, **kwargs)
-                toret = zip(*toret) # re-zip results from a generator
-            return toret
-        wrapped.cache = cache
-        return wrapped
-        
+    """        
     @staticmethod
     def BoxSizeParser(value):
         """
@@ -398,6 +392,23 @@ class DataSource:
             raise ValueError("BoxSize must be a scalar or three-vector")
         return boxsize
 
+    def cache_data(self, cache=True):
+        """
+        Cache/un-cache the return results of `read`
+        
+        Each column that is asked for via `read` will be cached, 
+        and returned from cache if asked for multiple times
+        """
+        # setup the caching read function
+        if cache:
+            if not hasattr(self.read, 'cache'):  # already cached
+                self._original_read = self.read
+                self.read = memoized(self.read)
+        # restore the original
+        else:
+            if hasattr(self.read, 'cache'):
+                self.read = self._original_read
+            
     def simple_read(self, columns):
         """ 
         Override to provide a method to read in all data at once 

--- a/nbodykit/measurestats.py
+++ b/nbodykit/measurestats.py
@@ -223,6 +223,10 @@ def compute_bianchi_poles(max_ell, datasource, pm, comm=None, log_level=logging.
     result = []
     result.append(A0)
     
+    # the x grid points (at point centers)
+    cell_size = pm.BoxSize / pm.Nmesh
+    xgrid = [(xi+0.5)*cell_size[i] for i, xi in enumerate(pm.x)]
+    
     for iell, ell in enumerate(ells[1:]):
         A_ell = numpy.zeros_like(pm.complex)
         
@@ -232,7 +236,7 @@ def compute_bianchi_poles(max_ell, datasource, pm, comm=None, log_level=logging.
             pm.real[:] = density[:]
         
             # apply the real-space transfer
-            bianchi_transfer(pm.real, pm.x, *integers, offset=offset)
+            bianchi_transfer(pm.real, xgrid, *integers, offset=offset)
                         
             # do the FT and apply the k-space kernel
             pm.r2c()

--- a/nbodykit/measurestats.py
+++ b/nbodykit/measurestats.py
@@ -225,7 +225,7 @@ def compute_bianchi_poles(max_ell, datasource, pm, comm=None, log_level=logging.
     
     # the x grid points (at point centers)
     cell_size = pm.BoxSize / pm.Nmesh
-    xgrid = [(xi+0.5)*cell_size[i] for i, xi in enumerate(pm.x)]
+    xgrid = [(ri+0.5)*cell_size[i] for i, ri in enumerate(pm.r)]
     
     for iell, ell in enumerate(ells[1:]):
         A_ell = numpy.zeros_like(pm.complex)

--- a/nbodykit/plugins/datasource/TracerCatalog.py
+++ b/nbodykit/plugins/datasource/TracerCatalog.py
@@ -81,11 +81,17 @@ class TracerCatalogDataSource(DataSource):
             
                 # store redshifts
                 redshifts += list(z)
-                
+        
+        # need N_data
+        N_data = 0
+        for [Position] in self.data.read(['Position'], full=False):
+            N_data += len(Position)
+        
         # gather everything to root
         coords_min = self.comm.gather(coords_min)
         coords_max = self.comm.gather(coords_max)
-        redshifts = self.comm.gather(redshifts)
+        redshifts  = self.comm.gather(redshifts)
+        N_data     = self.comm.gather(N_data)
         
         # only rank zero does the work, then broadcast
         if self.comm.rank == 0:
@@ -99,7 +105,7 @@ class TracerCatalogDataSource(DataSource):
             self._define_box(coords_min, coords_max)
     
             # compute the number density from the data
-            self._set_nbar(numpy.array(redshifts), alpha=1.0)
+            self._set_nbar(numpy.array(redshifts), alpha=1.*N_data/len(redshifts))
             
         # broadcast the results that rank 0 computed
         self.BoxSize   = self.comm.bcast(self.BoxSize)

--- a/nbodykit/plugins/datasource/TracerCatalog.py
+++ b/nbodykit/plugins/datasource/TracerCatalog.py
@@ -46,8 +46,8 @@ class TracerCatalogDataSource(DataSource):
     plugin_name = "TracerCatalog"
     
     def __init__(self, data, randoms, BoxSize=None, BoxPad=0.02, 
-                    compute_fkp_weights=False, P0_fkp=None, nbar=None, 
-                    fsky=None):
+                    compute_fkp_weights=False, P0_fkp=None, 
+                    nbar=None, fsky=None):
         """
         Finalize by performing several steps:
         
@@ -66,13 +66,18 @@ class TracerCatalogDataSource(DataSource):
         if self.cosmo is None:
             raise ValueError("please specify a input Cosmology to use in TracerCatalog")
     
+        # cache the return results
+        self.data.cache_data()
+        self.randoms.cache_data()
+    
         # need to compute cartesian min/max
         coords_min = numpy.array([numpy.inf]*3)
         coords_max = numpy.array([-numpy.inf]*3)
         
         # read the randoms in parallel
         redshifts = []
-        for [coords, z] in self.randoms.read(['Position', 'Redshift'], full=False):
+        columns = ['Position', 'Redshift', 'Weight']
+        for [coords, z, w] in self.randoms.read(columns, full=False):
             
             # global min/max of cartesian
             if len(coords):
@@ -84,7 +89,7 @@ class TracerCatalogDataSource(DataSource):
         
         # need N_data
         N_data = 0
-        for [Position] in self.data.read(['Position'], full=False):
+        for [Position, z, w] in self.data.read(['Position', 'Redshift', 'Weight'], full=False):
             N_data += len(Position)
         
         # gather everything to root

--- a/nbodykit/plugins/datasource/TracerCatalog.py
+++ b/nbodykit/plugins/datasource/TracerCatalog.py
@@ -70,9 +70,9 @@ class TracerCatalogDataSource(DataSource):
         coords_min = numpy.array([numpy.inf]*3)
         coords_max = numpy.array([-numpy.inf]*3)
         
-        # read the data in parallel
+        # read the randoms in parallel
         redshifts = []
-        for [coords, z] in self.data.read(['Position', 'Redshift'], full=False):
+        for [coords, z] in self.randoms.read(['Position', 'Redshift'], full=False):
             
             # global min/max of cartesian
             if len(coords):

--- a/nbodykit/plugins/datasource/TracerCatalog.py
+++ b/nbodykit/plugins/datasource/TracerCatalog.py
@@ -91,7 +91,7 @@ class TracerCatalogDataSource(DataSource):
         coords_min = self.comm.gather(coords_min)
         coords_max = self.comm.gather(coords_max)
         redshifts  = self.comm.gather(redshifts)
-        N_data     = self.comm.gather(N_data)
+        N_data     = self.comm.reduce(N_data)
         
         # only rank zero does the work, then broadcast
         if self.comm.rank == 0:

--- a/nbodykit/utils/config.py
+++ b/nbodykit/utils/config.py
@@ -211,17 +211,13 @@ class ConstructorSchema(OrderedDict):
         
         # add new argument (with empty subfields)
         if not self.contains(name):
-            obj[suffix] = Argument(name, required, nargs=nargs, type=type, default=default, choices=choices, help=help)
+            obj[suffix] = Argument(name, required, nargs=nargs, type=type, default=default, 
+                                    choices=choices, help=help)
+                                    
         # overwrite existing object (copying the subfields)
         else:
-            arg             = obj[name]._asdict()
-            arg['type']     = type
-            arg['default']  = default
-            arg['choices']  = choices
-            arg['help']     = help
-            arg['required'] = required
-            arg['nargs']    = nargs
-            obj[suffix]     = Argument(**arg)
+            obj[suffix] = obj[suffix]._replace(type=type, default=default, choices=choices, 
+                                                help=help, required=required, nargs=nargs)
      
     def _arg_info(self, name, arg, indent=0):
         """


### PR DESCRIPTION
adds a few things:

* db59c5b adds a decorator in extensionpts.py and a `cache_data` function to DataSource that can turn on/off cacheing of the return values of the `read()` function
* idea is that you could use decorator in DataSource Plugins if you always want to cache or use the `cache_data` function to turn it on/off 
*  cleaning up TracerCatalog to use randoms to define box and nbar -- more clean up needed