### PR TITLE
fixes `output` handling in nbkit.py -- set `output=None` for stdout 

### DIFF
--- a/bin/nbkit.py
+++ b/bin/nbkit.py
@@ -99,11 +99,9 @@ def main():
         stream = MPI.COMM_WORLD.bcast(stream)
     params, extra = Algorithm.parse_known_yaml(alg_name, stream)
         
-    output = getattr(extra, 'output', None)
-    
     # output is required
-    if output is None:
-        raise ValueError("argument -o/--output is required")
+    if not hasattr(extra, 'output'):
+        raise ValueError("parameter `output` is required in configuration; set to `None` for stdout")
             
     # initialize the algorithm and run
     alg_class = getattr(algorithms, alg_name)
@@ -111,7 +109,7 @@ def main():
 
     # run and save
     result = alg.run()
-    alg.save(output, result) 
+    alg.save(extra.output, result) 
        
 if __name__ == '__main__':
     main()

--- a/nbodykit/plugins/algorithms/PeriodicBox.py
+++ b/nbodykit/plugins/algorithms/PeriodicBox.py
@@ -1,6 +1,7 @@
 from nbodykit.extensionpoints import Algorithm
 from nbodykit.extensionpoints import DataSource, Transfer, Painter
 
+import os
 import numpy
 import logging
 


### PR DESCRIPTION
changes:

* if `output` key is left blank in config file (which sets it to None), algorithms can interpret this as stdout
* only valid for Describe algorithm right now
* fixes an output bug in PeriodicBox multipoles
