### PR TITLE
only root logs warning about ignored config parameters; FKP should recenter to [-L/2, L/2]

### DIFF
--- a/bin/nbkit.py
+++ b/bin/nbkit.py
@@ -117,7 +117,7 @@ def main():
     output = extra.pop('output')
     
     # print warning if extra parameters ignored
-    if len(extra):
+    if MPI.COMM_WORLD.rank == 0 and len(extra):
         ignored = "[ %s ]" % ", ".join(["'%s'" %k for k in extra.keys()])
         logging.warning("the following keywords to `nbkit.py` have been ignored: %s" %ignored)
             

--- a/nbodykit/fkp.py
+++ b/nbodykit/fkp.py
@@ -365,11 +365,11 @@ class FKPCatalog(object):
             default_z = stream.isdefault('Redshift', redshift)
             default_nbar = stream.isdefault('Nbar', nbar)
         
-            # recentered cartesian coordinates (between 0 and BoxSize)
-            pos = coords - self.mean_coordinate_offset + self.BoxSize*0.5
+            # recentered cartesian coordinates (between -BoxSize/2 and BoxSize/2)
+            pos = coords - self.mean_coordinate_offset
             
-            # enforce that position is between (0, L)
-            lim = (pos < 0)|(pos > self.BoxSize)
+            # enforce that position is between (-L/2, L/2)
+            lim = (pos < -0.5*self.BoxSize)|(pos > 0.5*self.BoxSize)
             if lim.any():
                 args = (list(lim.sum(axis=0)), name, self.BoxSize)
                 errmsg = "%s '%s' particles out of bounds in each dimension when using BoxSize %s" %args

--- a/nbodykit/fkp.py
+++ b/nbodykit/fkp.py
@@ -219,9 +219,7 @@ class FKPCatalog(object):
         if self.BoxSize is None:
             delta *= 1.0 + self.BoxPad
             self.BoxSize = numpy.ceil(delta) # round up to nearest integer
-            
-        self.mean_coordinate_offset -= self.BoxSize*0.5
-        
+                    
     def _compute_randoms_nbar(self, redshift):
         """
         Compute `n(z)` from the `randoms` by making a spline
@@ -367,8 +365,8 @@ class FKPCatalog(object):
             default_z = stream.isdefault('Redshift', redshift)
             default_nbar = stream.isdefault('Nbar', nbar)
         
-            # recentered cartesian coordinates
-            pos = coords - self.mean_coordinate_offset
+            # recentered cartesian coordinates (between 0 and BoxSize)
+            pos = coords - self.mean_coordinate_offset + self.BoxSize*0.5
             
             # enforce that position is between (0, L)
             lim = (pos < 0)|(pos > self.BoxSize)

--- a/nbodykit/fkp.py
+++ b/nbodykit/fkp.py
@@ -220,7 +220,7 @@ class FKPCatalog(object):
             delta *= 1.0 + self.BoxPad
             self.BoxSize = numpy.ceil(delta) # round up to nearest integer
             
-        self.mean_coordinate_offset += self.BoxSize*0.5
+        self.mean_coordinate_offset -= self.BoxSize*0.5
         
     def _compute_randoms_nbar(self, redshift):
         """

--- a/nbodykit/fkp.py
+++ b/nbodykit/fkp.py
@@ -219,6 +219,8 @@ class FKPCatalog(object):
         if self.BoxSize is None:
             delta *= 1.0 + self.BoxPad
             self.BoxSize = numpy.ceil(delta) # round up to nearest integer
+            
+        self.mean_coordinate_offset += self.BoxSize*0.5
         
     def _compute_randoms_nbar(self, redshift):
         """
@@ -368,8 +370,8 @@ class FKPCatalog(object):
             # recentered cartesian coordinates
             pos = coords - self.mean_coordinate_offset
             
-            # enforce that position is between -L/2 and L/2
-            lim = (pos < -0.5*self.BoxSize)|(pos > self.BoxSize*0.5)
+            # enforce that position is between (0, L)
+            lim = (pos < 0)|(pos > self.BoxSize)
             if lim.any():
                 args = (list(lim.sum(axis=0)), name, self.BoxSize)
                 errmsg = "%s '%s' particles out of bounds in each dimension when using BoxSize %s" %args

--- a/nbodykit/measurestats.py
+++ b/nbodykit/measurestats.py
@@ -266,7 +266,7 @@ def compute_bianchi_poles(comm, max_ell, catalog, Nmesh,
             # and save
             A_ell[:] += amp*pm.complex[:]
             
-        # apply the CIC transfer and save
+        # apply the gridding transfer and save
         transfer(pm, A_ell)
         result.append(A_ell)
         if rank == 0: 

--- a/nbodykit/utils/config.py
+++ b/nbodykit/utils/config.py
@@ -91,7 +91,6 @@ def ReadConfigFile(config_stream, schema):
         if isinstance(plugins, str):
             plugins = [plugins]
         for plugin in plugins: load(plugin)
-        unknown.X = plugins 
         config.pop('X')
     
     # now load cosmology


### PR DESCRIPTION
* a few tests about FKP recentering  --> should be to [-L/2, L/2] for correctness
* previous test of this issue was wrong, which I discovered when adding the test that all particles are within the box