### PR TITLE
potential build framework with nightly cron jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 examples/data
 examples/nbodykit-data.tar.gz
 examples/output
+nersc/cori
+nersc/edison

--- a/nersc/activate.sh
+++ b/nersc/activate.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
 
+# can supply 0 or 1 argument
+if [ "$#" -gt 1 ]; then
+    echo "usage: activate.sh [latest|stable]"
+    exit 1
+fi
+
+# if no version provided, use 'stable'
+if [ $# -eq 0 ]; then
+    version="stable"
+elif [[ "$1" -ne "stable" || "$1" -ne "latest" ]]; then
+    echo "valid version names are 'stable' and 'latest'"
+    exit 1
+else
+    version=$1
+fi
+
 if [[ -n $BASH_VERSION ]]; then
     _SCRIPT_LOCATION=${BASH_SOURCE[0]}
 elif [[ -n $ZSH_VERSION ]]; then
@@ -10,13 +26,15 @@ else
 fi
 
 NBKITROOT=`dirname ${_SCRIPT_LOCATION}`
-NBKITROOT=`readlink -f $NBKITROOT/..`
 
+# load default python
 module load python/2.7-anaconda
 
+# activate python-mpi-bcast
 source /usr/common/contrib/bccp/python-mpi-bcast/nersc/activate.sh
 
-bcast ${NBKITROOT}/nbodykit-dep.tar.gz ${NBKITROOT}/nbodykit.tar.gz
+# load the specified version
+bcast ${NBKITROOT}/nbodykit-dep.tar.gz ${NBKITROOT}/nbodykit-${version}.tar.gz
 
 function srun-nbkit {
     local np=

--- a/nersc/activate.sh
+++ b/nersc/activate.sh
@@ -26,6 +26,7 @@ else
 fi
 
 NBKITROOT=`dirname ${_SCRIPT_LOCATION}`
+NBKITROOT=`readlink -f $NBKITROOT`
 
 # load default python
 module load python/2.7-anaconda

--- a/nersc/build.sh
+++ b/nersc/build.sh
@@ -8,7 +8,7 @@ while getopts ":h" opt; do
       echo "    build.sh -h                      Display this help message."
       echo "    build.sh all <version>           Build both the source and the dependencies."
       echo "    build.sh source <version>        Build only the source."
-      echo "    build.sh deps <version>          Build only the dependencies."
+      echo "    build.sh deps                    Build only the dependencies."
       exit 0
       ;;
    \? )
@@ -20,33 +20,29 @@ done
 shift $((OPTIND -1))
 
 subcommand=$1; shift  # Remove build.sh from the argument list
-if [ $# != 1 ]
+if [[ "$subcommand" != "deps" && $# != 1 ]]
 then
     echo "please provide a <version> to build as the 2nd argument"
     exit 1
 fi
 
 version=$1; shift
+mkdir -p ${NERSC_HOST}
 
 # activate python-mpi-bcast
 source /usr/common/contrib/bccp/python-mpi-bcast/activate.sh
 
 case "$subcommand" in
-  
+
   all )
-    mkdir -p ${NERSC_HOST}/${version}
-    MPICC=cc bundle-pip ${NERSC_HOST}/${version}/nbodykit-dep.tar.gz -r ../requirements.txt 
-    bundle-pip ${NERSC_HOST}/nbodykit.tar.gz ..
+    MPICC=cc bundle-pip ${NERSC_HOST}/nbodykit-dep.tar.gz -r ../requirements.txt
+    bundle-pip ${NERSC_HOST}/nbodykit-${version}.tar.gz ..
   ;;
   source )
-    version=$1; shift
-    mkdir -p ${NERSC_HOST}/${version}
-    bundle-pip ${NERSC_HOST}/nbodykit.tar.gz ..
+    bundle-pip ${NERSC_HOST}/nbodykit-${version}.tar.gz ..
     ;;
   deps )
-    version=$1; shift
-    mkdir -p ${NERSC_HOST}/${version}
-    MPICC=cc bundle-pip ${NERSC_HOST}/${version}/nbodykit-dep.tar.gz -r ../requirements.txt 
+    MPICC=cc bundle-pip ${NERSC_HOST}/nbodykit-dep.tar.gz -r ../requirements.txt
     ;;
    * )
     echo "invalid build choice -- choose from 'source' or 'deps'"

--- a/nersc/build.sh
+++ b/nersc/build.sh
@@ -26,13 +26,14 @@ then
     exit 1
 fi
 
+version=$1; shift
+
 # activate python-mpi-bcast
 source /usr/common/contrib/bccp/python-mpi-bcast/activate.sh
 
 case "$subcommand" in
   
   all )
-    version=$1; shift
     mkdir -p ${NERSC_HOST}/${version}
     MPICC=cc bundle-pip ${NERSC_HOST}/${version}/nbodykit-dep.tar.gz -r ../requirements.txt 
     bundle-pip ${NERSC_HOST}/nbodykit.tar.gz ..

--- a/nersc/build.sh
+++ b/nersc/build.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-# parse options
+# print the usage
 while getopts ":h" opt; do
   case ${opt} in
     h )
       echo "usage:"
-      echo "    build.sh -h                      Display this help message."
-      echo "    build.sh all <version>           Build both the source and the dependencies."
-      echo "    build.sh source <version>        Build only the source."
-      echo "    build.sh deps                    Build only the dependencies."
+      echo "    build.sh -h            Display this help message."
+      echo "    build.sh all           Build both the source and the dependencies."
+      echo "    build.sh source        Build only the source."
+      echo "    build.sh deps          Build only the dependencies."
       exit 0
       ;;
    \? )
@@ -19,21 +19,31 @@ while getopts ":h" opt; do
 done
 shift $((OPTIND -1))
 
-subcommand=$1; shift  # Remove build.sh from the argument list
-if [[ "$subcommand" != "deps" && $# != 1 ]]
-then
-    echo "please provide a <version> to build as the 2nd argument"
-    exit 1
-fi
+# get the subcommand and shorten the argument list
+subcommand=$1; shift
 
-version=$1; shift
+# get the current git branch
+curr_branch=$(git rev-parse --abbrev-ref HEAD)
+case "$curr_branch" in 
+    master )
+       version='stable'
+    ;;
+    develop )
+       version='latest'
+    ;;
+    * )
+       echo "when running build.sh, current git branch should be 'master' or 'develop'"
+       exit 1
+    ;;
+esac
+
+# make the build directory
 mkdir -p ${NERSC_HOST}
 
 # activate python-mpi-bcast
 source /usr/common/contrib/bccp/python-mpi-bcast/activate.sh
 
 case "$subcommand" in
-
   all )
     MPICC=cc bundle-pip ${NERSC_HOST}/nbodykit-dep.tar.gz -r ../requirements.txt
     bundle-pip ${NERSC_HOST}/nbodykit-${version}.tar.gz ..

--- a/nersc/deploy.sh
+++ b/nersc/deploy.sh
@@ -15,9 +15,6 @@ fi
 version=$1
 PREFIX=${NERSC_HOST}
 
-# setup build directory
-install -d /usr/common/contrib/bccp/nbodykit/
-
 # move the activate script to the build dir
 install activate.sh /usr/common/contrib/bccp/nbodykit/
 

--- a/nersc/deploy.sh
+++ b/nersc/deploy.sh
@@ -1,20 +1,29 @@
 #! /bin/bash
 
 if [ "x$1" == "x-h" ] || [ "x$1" == "x" ] ; then
-    echo "usage: deploy.sh <version>"
+    echo "usage: deploy.sh <latest|stable>"
     exit 1
 fi
+
+
+# check input version
+if [[ "$1" -ne "stable" || "$1" -ne "latest" ]]; then
+    echo "valid version names are 'stable' and 'latest'"
+    exit 1
+fi
+
 version=$1
 PREFIX=${NERSC_HOST}
 
 # setup build directory
-install -d /usr/common/contrib/bccp/nbodykit/$version
+install -d /usr/common/contrib/bccp/nbodykit/
 
 # move the activate script to the build dir
-install activate.sh /usr/common/contrib/bccp/nbodykit/$version
+install activate.sh /usr/common/contrib/bccp/nbodykit/
 
 # copy the necessary tar files
-rsync --exclude='*.gz-*' -ar $PREFIX/$version/* /usr/common/contrib/bccp/nbodykit/$version/
+rsync --exclude='*.gz-*' -ar $PREFIX/nbodykit-dep.tar.gz /usr/common/contrib/bccp/nbodykit/
+rsync --exclude='*.gz-*' -ar $PREFIX/nbodykit-$version.tar.gz /usr/common/contrib/bccp/nbodykit/
 
 function tree {
     SEDMAGIC='s;[^/]*/;|____;g;s;____|; |;g'

--- a/nersc/nightly-build.cron
+++ b/nersc/nightly-build.cron
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# full path of the nightly build script
+script_path=$(readlink -f nightly-build.sh)
+
+# do the nightly build (only add cron job if not present)
+job="00 00 * * * bash -l $script_path"
+( crontab -l | grep -Fq "$job" | echo "$job" ) | crontab -
+

--- a/nersc/nightly-build.sh
+++ b/nersc/nightly-build.sh
@@ -18,7 +18,7 @@ bundle-pip ${NERSC_HOST}/nbodykit-stable.tar.gz git+https://github.com/bccp/nbod
 rsync ${NERSC_HOST}/nbodykit-stable.tar.gz /usr/common/contrib/bccp/nbodykit/
 
 # build the dependencies from the requirements.txt file
-bundle-pip ${NERSC_HOST}/nbodykit-dep.tar.gz https://raw.githubusercontent.com/bccp/nbodykit/develop/requirements.txt
+bundle-pip ${NERSC_HOST}/nbodykit-dep.tar.gz -r https://raw.githubusercontent.com/bccp/nbodykit/develop/requirements.txt
 rsync ${NERSC_HOST}/nbodykit-dep.tar.gz /usr/common/contrib/bccp/nbodykit/
 
 # remove the temporary directory

--- a/nersc/nightly-build.sh
+++ b/nersc/nightly-build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -l
+
+# change to a temporary directory
+cd $(mktemp -d)
+
+# make the build directory
+mkdir -p ${NERSC_HOST}
+
+# activate python-mpi-bcast
+source /usr/common/contrib/bccp/python-mpi-bcast/activate.sh
+
+# build the "latest" source from the "develop" branch
+bundle-pip ${NERSC_HOST}/nbodykit-latest.tar.gz git+https://github.com/bccp/nbodykit.git@develop
+rsync ${NERSC_HOST}/nbodykit-latest.tar.gz /usr/common/contrib/bccp/nbodykit/
+
+# build the "stable" source from the "master" branch
+bundle-pip ${NERSC_HOST}/nbodykit-stable.tar.gz git+https://github.com/bccp/nbodykit.git@master
+rsync ${NERSC_HOST}/nbodykit-stable.tar.gz /usr/common/contrib/bccp/nbodykit/
+
+# build the dependencies from the requirements.txt file
+bundle-pip ${NERSC_HOST}/nbodykit-dep.tar.gz https://raw.githubusercontent.com/bccp/nbodykit/develop/requirements.txt
+rsync ${NERSC_HOST}/nbodykit-dep.tar.gz /usr/common/contrib/bccp/nbodykit/
+
+# remove the temporary directory
+rm -r $(pwd)
+

--- a/nersc/nightly-build.sh
+++ b/nersc/nightly-build.sh
@@ -18,7 +18,7 @@ bundle-pip ${NERSC_HOST}/nbodykit-stable.tar.gz git+https://github.com/bccp/nbod
 rsync ${NERSC_HOST}/nbodykit-stable.tar.gz /usr/common/contrib/bccp/nbodykit/
 
 # build the dependencies from the requirements.txt file
-bundle-pip ${NERSC_HOST}/nbodykit-dep.tar.gz -r https://raw.githubusercontent.com/bccp/nbodykit/develop/requirements.txt
+MPICC=cc bundle-pip ${NERSC_HOST}/nbodykit-dep.tar.gz -r https://raw.githubusercontent.com/bccp/nbodykit/develop/requirements.txt
 rsync ${NERSC_HOST}/nbodykit-dep.tar.gz /usr/common/contrib/bccp/nbodykit/
 
 # remove the temporary directory


### PR DESCRIPTION
#### Build framework
* the setup right now builds a `stable` source tar which tracks the `master` HEAD and a `latest` tarball which tracks the `develop` branch
* in `/usr/common/contrib/bccp/nbodykit`, there is a `nbodykit-latest.tar.gz` and `nbodykit-stable.tar.gz`, as well as `activate.sh`
* the intended usage is then `source /usr/common/contrib/bccp/nbodykit/activate.sh`. If no arguments are provided, the `stable` tar ball is loaded and `latest` and `stable` can be passed to the script too. 

#### Nightly builds

* the script `nightly-build.sh` installs the head of develop and master from github and installs the dependencies as well -- the dependencies take ~10-20 minutes to install because of `pfft-python` so eventually it would be good to implement some sort of version checking
* `bash nightly-build.cron` will add a cron job that runs `nightly-build.sh` at midnight each night. you can run this on edison and cori independently to add to the crontab for each machine 
* I've set the crontab up so we will see how well it works -- if we want to get really fancy, we can send emails if the script fails for some reason