### PR TITLE
Cleans up the parallel random seeds in several places

### DIFF
--- a/examples/fiber_collisions/test_fc.params
+++ b/examples/fiber_collisions/test_fc.params
@@ -4,4 +4,6 @@ datasource:
     names: [ra, dec, z]
     usecols: [ra, dec, z]
     degrees: True
+
+seed: 42
 output: ${NBKIT_HOME}/examples/output/test_fiber_collisions

--- a/examples/subsample/test_tpmsnapshot_mwhite.params
+++ b/examples/subsample/test_tpmsnapshot_mwhite.params
@@ -2,9 +2,9 @@ datasource:
   plugin: TPMSnapshot
   path: ${NBKIT_CACHE}/data/tpm_1.0000.bin
   BoxSize: 384
-
+ 
 Nmesh: 256
-seed: 12345
+seed: 42
 smoothing: 20.0
 ratio: 0.01
 format: mwhite

--- a/nbodykit/plugins/datasource/UniformBox.py
+++ b/nbodykit/plugins/datasource/UniformBox.py
@@ -1,6 +1,8 @@
-from nbodykit.extensionpoints import DataSource
 import numpy
 import logging
+
+from nbodykit.extensionpoints import DataSource
+from nbodykit import utils
 
 logger = logging.getLogger('UniformBox')
          
@@ -17,12 +19,11 @@ class UniformBoxDataSource(DataSource):
     
     def __init__(self, N, BoxSize, max_speed=500., mu_logM=13.5, sigma_logM=0.5, seed=None):        
         
-        # initalize a random state for each rank
+        # create the random state from the global seed and comm size
         if self.seed is not None:
-            seed = self.seed*(self.comm.rank+1)
-            self.random = numpy.random.RandomState(seed)
+            self.random_state = utils.local_random_state(self.seed, self.comm)
         else:
-            self.random = numpy.random
+            self.random_state = numpy.random
             
     @classmethod
     def register(cls):
@@ -54,9 +55,9 @@ class UniformBoxDataSource(DataSource):
         toret = {}
         shape = (self.N, 3)
         
-        toret['Position'] = self.random.uniform(size=shape) * self.BoxSize
-        toret['Velocity'] = 2*self.max_speed * self.random.uniform(size=shape) - self.max_speed
-        toret['LogMass']  = self.random.normal(loc=self.mu_logM, scale=self.sigma_logM, size=self.N)
+        toret['Position'] = self.random_state.uniform(size=shape) * self.BoxSize
+        toret['Velocity'] = 2*self.max_speed * self.random_state.uniform(size=shape) - self.max_speed
+        toret['LogMass']  = self.random_state.normal(loc=self.mu_logM, scale=self.sigma_logM, size=self.N)
         toret['Mass']     = 10**(toret['LogMass'])
         
         return toret


### PR DESCRIPTION
* use the new function `local_random_state` from `utils` module
* uses a global seed to generate new random seeds (any 32 bit integer) for all ranks
* hopefully this is good enough to reduce any possible correlations between random numbers on different ranks

* also fixes a bug in Subsample where the random seed wasn't being used