### PR TITLE
remove `registry` from plugins; handle everything through plugin_manager

### DIFF
--- a/nbodykit/__init__.py
+++ b/nbodykit/__init__.py
@@ -12,7 +12,7 @@ bin_dir      = os.path.join(pkg_dir, 'bin')
 # get the singleton plugin manager, with core plugins loaded
 core_paths = [os.path.join(pkg_dir, 'nbodykit', 'core')]
 core_paths.append(os.path.join(pkg_dir, 'nbodykit', 'io'))
-plugin_manager = PluginManager.get(core_paths, qualprefix='nbodykit')
+plugin_manager = PluginManager.get(paths=core_paths, qualprefix='nbodykit')
 
 # create namespaces for the core plugins
 algorithms  = Namespace(**plugin_manager['Algorithm'])

--- a/nbodykit/__init__.py
+++ b/nbodykit/__init__.py
@@ -9,10 +9,10 @@ pkg_dir      = os.path.abspath(os.path.join(__file__, '..', '..'))
 examples_dir = os.path.join(pkg_dir, 'examples')
 bin_dir      = os.path.join(pkg_dir, 'bin')
 
-# get the singleton plugin manager, with core plugins loaded
+# create the singleton plugin manager, with core plugins loaded
 core_paths = [os.path.join(pkg_dir, 'nbodykit', 'core')]
 core_paths.append(os.path.join(pkg_dir, 'nbodykit', 'io'))
-plugin_manager = PluginManager.get(paths=core_paths, qualprefix='nbodykit')
+plugin_manager = PluginManager.create(core_paths, qualprefix='nbodykit')
 
 # create namespaces for the core plugins
 algorithms  = Namespace(**plugin_manager['Algorithm'])

--- a/nbodykit/core/algorithms/FiberCollisions.py
+++ b/nbodykit/core/algorithms/FiberCollisions.py
@@ -3,7 +3,8 @@ from nbodykit import fof, utils
 import numpy
 
 def RaDecDataSource(d):
-    source = DataSource.registry()['RaDecRedshift']
+    from nbodykit import plugin_manager
+    source = plugin_manager.get_plugin('RaDecRedshift')
     d['unit_sphere'] = True
     return source.from_config(d)
             

--- a/nbodykit/plugins/manager.py
+++ b/nbodykit/plugins/manager.py
@@ -24,7 +24,7 @@ class PluginManager(object):
     supported_types.update(**io_extension_points())
 
     @classmethod
-    def get(cls, paths, qualprefix="nbodykit.core.user"):
+    def get(cls, paths=[], qualprefix="nbodykit.core.user"):
         """
         Return a PluginManager instance
         
@@ -40,6 +40,8 @@ class PluginManager(object):
             This is used to load the builtin plugins in :mod:`nbodykit.core`
         """
         if not cls._instance:
+            if not len(paths):
+                raise ValueError("please provide a list of paths to search for plugins")
             PluginManager._instance = cls(paths, qualprefix=qualprefix)
         return cls._instance
 

--- a/nbodykit/plugins/manager.py
+++ b/nbodykit/plugins/manager.py
@@ -247,3 +247,48 @@ class PluginManager(object):
             raise ValueError("name collision for plugin '%s'; please specify 'type'" %name)
         else:
             raise ValueError("plugin with name '%s' not found" %name)
+            
+    def format_help(self, extension, *plugins):
+        """
+        Return a string specifying the `help` for each of the plugins
+        specified of extension type `extension`
+        
+        If no `plugins` are specified, format the help message for 
+        all plugins registered as subclasses of `extension`
+        
+        Parameters
+        ----------
+        extension : str
+            the string specifying the extension type; should be in 
+            :attr:`PluginManager.supported_types`
+        plugins : list of str
+            strings specifying the names of plugins of the specified type
+            to format together
+        
+        Returns
+        -------
+        help_msg : str
+            the formatted help message string for the specified plugins
+        """
+        if extension not in self.supported_types:
+            raise ValueError("`extension` argument should be one of %s" %list(self.supported_types))
+        
+        registry = self[extension]
+        if not len(plugins):
+            plugins = list(registry)
+            
+        s = []
+        for k in plugins:
+            
+            if k not in registry:
+                raise ValueError("'%s' is not a valid plugin name for type '%s'" %(k, extension))
+            
+            header = "Plugin : %s  Extension Type : %s" % (k, extension)
+            s.append(header)
+            s.append("=" * (len(header)))
+            s.append(registry[k].schema.format_help() + "\n")
+
+        if not len(s):
+            return "No available plugins registered for type '%s'" %extension
+        else:
+            return '\n'.join(s) + '\n'

--- a/nbodykit/plugins/manager.py
+++ b/nbodykit/plugins/manager.py
@@ -24,12 +24,17 @@ class PluginManager(object):
     supported_types.update(**io_extension_points())
 
     @classmethod
-    def get(cls, paths=[], qualprefix="nbodykit.core.user"):
+    def create(cls, paths, qualprefix="nbodykit.core.user"):
         """
-        Return a PluginManager instance
+        Create the PluginManager instance
         
         Uses the singleton pattern to ensure that only one
         plugin manager exists
+        
+        Raises
+        ------
+        ValueError : 
+            if the PluginManager already exists
         
         Parameters
         ----------
@@ -39,10 +44,24 @@ class PluginManager(object):
             the prefix to build a qualified name in ``sys.modules``. 
             This is used to load the builtin plugins in :mod:`nbodykit.core`
         """
+        if cls._instance:
+            raise ValueError("PluginManager instance already exists; use PluginManager.get() to access")
+        
+        PluginManager._instance = cls(paths, qualprefix=qualprefix)
+        return cls._instance
+        
+    @classmethod
+    def get(cls):
+        """
+        Return the PluginManager
+        
+        Raises
+        ------
+        ValueError : 
+            if the PluginManager has not been created yet
+        """
         if not cls._instance:
-            if not len(paths):
-                raise ValueError("please provide a list of paths to search for plugins")
-            PluginManager._instance = cls(paths, qualprefix=qualprefix)
+            raise ValueError("PluginManager instance has not been created yet; see PluginManager.create()")
         return cls._instance
 
     def __init__(self, paths, qualprefix="nbodykit.core.user"):


### PR DESCRIPTION
I don't think the registry attribute is necessary

handling everything through plugin_manager simplifies a lot of the code