### PR TITLE
addresses Poisson sampling in N-dimensions 

### DIFF
--- a/nbodykit/meshtools.py
+++ b/nbodykit/meshtools.py
@@ -54,14 +54,14 @@ class MeshSlab(object):
         Return the local shape of the mesh on this rank, as determined
         by the input coordinates array
         """
-        return [numpy.shape(self._coords[i])[i] for i in range(self.ndim)]
+        return tuple([numpy.shape(self._coords[i])[i] for i in range(self.ndim)])
     
     @property
     def shape(self):
         """
         Return the shape of the slab
         """
-        return [s for i, s in enumerate(self.meshshape) if i != self.axis]
+        return tuple([s for i, s in enumerate(self.meshshape) if i != self.axis])
 
     @property
     def hermitian_symmetric(self):
@@ -125,7 +125,7 @@ class MeshSlab(object):
         ----------
         los: array_like,
             the direction of the line-of-sight, which `mu` is defined
-            with respect to. must have a norm of 1.
+            with respect to; must have a norm of 1.
         
         Returns
         -------
@@ -216,6 +216,8 @@ def SlabIterator(coords, axis=0, symmetry_axis=None):
     """    
     # number of dimensions in the mesh
     ndim = len(coords)
+    if ndim != 3:
+        raise NotImplementedError("SlabIterator can only be used on 3D arrays")
         
     # account for negative axes
     if axis < 0: axis += ndim

--- a/nbodykit/meshtools.py
+++ b/nbodykit/meshtools.py
@@ -21,10 +21,11 @@ class MeshSlab(object):
         symmetry_axis : int, optional
             if provided, the axis that has been compressed due to Hermitian symmetry
         """
-        self._index       = islab
-        self.axis        = axis
+        self.ndim          = len(coords)
+        self._index        = islab
+        self.axis          = axis
         self.symmetry_axis = symmetry_axis
-        self._coords     = coords
+        self._coords       = coords
         
         # make sure symmetry_axis > 0 (sanity check)
         if self.hermitian_symmetric and self.symmetry_axis < 0:
@@ -43,7 +44,7 @@ class MeshSlab(object):
         Return an indexing list appropriate for selecting the slicing the 
         appropriate slab out of a full 3D array of shape (Nx, Ny, Nz)
         """
-        toret = [slice(None), slice(None), slice(None)]
+        toret = [slice(None)]*self.ndim
         toret[self.axis] = self._index
         return toret
         
@@ -53,7 +54,7 @@ class MeshSlab(object):
         Return the local shape of the mesh on this rank, as determined
         by the input coordinates array
         """
-        return [numpy.shape(self._coords[i])[i] for i in [0, 1, 2]]
+        return [numpy.shape(self._coords[i])[i] for i in range(self.ndim)]
     
     @property
     def shape(self):
@@ -91,6 +92,9 @@ class MeshSlab(object):
             the coordinate array for dimension `i` on the slab; see the 
             note about the shape of the return array for details
         """
+        if i < 0: i += self.ndim
+        assert 0 <= i < self.ndim, "i should be between 0 and %d" %self.ndim
+        
         if i != self.axis:
             return numpy.take(self._coords[i], 0, axis=self.axis)
         else:
@@ -109,7 +113,7 @@ class MeshSlab(object):
         array_like, (slab.shape)
             the square of coordinate mesh at each point in the slab
         """
-        return self.coords(0)**2 + self.coords(1)**2 + self.coords(2)**2
+        return sum(self.coords(i)**2 for i in range(self.ndim))
 
     def mu(self, los):
         """
@@ -129,7 +133,7 @@ class MeshSlab(object):
             the `mu` value at each point in the slab
         """
         with numpy.errstate(invalid='ignore'):            
-            return sum(self.coords(i) * los[i] for i in range(3)) / self.norm2()**0.5
+            return sum(self.coords(i) * los[i] for i in range(self.ndim)) / self.norm2()**0.5
 
     @property
     def nonsingular(self):
@@ -209,20 +213,24 @@ def SlabIterator(coords, axis=0, symmetry_axis=None):
         the index of the mesh axis to iterate over
     symmetry_axis : int, optional
         if provided, the axis that has been compressed due to Hermitian symmetry
-    """        
+    """    
+    # number of dimensions in the mesh
+    ndim = len(coords)
+        
     # account for negative axes
-    if axis < 0: axis += 3
-    if symmetry_axis is not None and symmetry_axis < 0: symmetry_axis += 3
+    if axis < 0: axis += ndim
+    assert 0 <= axis < ndim, "axis should be between 0 and %d" %ndim
+    if symmetry_axis is not None and symmetry_axis < 0: symmetry_axis += ndim
     
     # this will only work if shapes are: [(Nx, 1, 1), (1, Ny, 1), (1, 1, Nz)]
     # mainly a sanity check to make sure things work
     shapes = [numpy.shape(x) for x in coords]
-    if shapes[0][1] != 1 or shapes[0][2] != 1:
-        raise ValueError("1st coordinate array should have shape (Nx, 1, 1)")
-    if shapes[1][0] != 1 or shapes[1][2] != 1:
-        raise ValueError("2nd coordinate array should have shape (1, Ny, 1)")
-    if shapes[2][0] != 1 or shapes[2][1] != 1:
-        raise ValueError("3rd coordinate array should have shape (1, 1, Nz)")
+    mesh_size = [shape[i] for i, shape in enumerate(shapes)]
+    for i in range(ndim):
+        desired_shape = numpy.ones(ndim)
+        desired_shape[i] = mesh_size[i]
+        if shapes[i] != tuple(desired_shape):
+            raise ValueError("coordinate array shape mismatch")
     
     # iterate over the specified axis, slab by slab
     N = numpy.shape(coords[axis])[axis]

--- a/nbodykit/mockmaker.py
+++ b/nbodykit/mockmaker.py
@@ -232,7 +232,10 @@ def poisson_sample_to_points(delta, displacement, pm, nbar, f=0., bias=1., seed=
     Returns
     -------
     pos : array_like, (N, 3)
-        the Cartesian positions of the particles in the box     
+        the Cartesian positions of each of the generated particles
+    vel : array_like, (N, 3)
+        the velocity "offsets" of each of the generated particles in the same
+        units as the ``pos`` array
     """
     if comm is None:
         comm = MPI.COMM_WORLD
@@ -260,23 +263,27 @@ def poisson_sample_to_points(delta, displacement, pm, nbar, f=0., bias=1., seed=
         N = None
     N = ScatterArray(N, comm, root=0)
     
-    Ntot = comm.allreduce(N.sum()) # the collective number of points
-    Nlocal = N.sum() # local number of points
-    pts = N.nonzero() # indices of nonzero points
-    
-    # setup the coordinate grid
-    x = numpy.squeeze(delta.pm.x[0])[pts[0]]
-    y = numpy.squeeze(delta.pm.x[1])[pts[1]]
-    z = numpy.squeeze(delta.pm.x[2])[pts[2]]
+    Ntot = comm.allreduce(N.sum()) # the collective number of particles
+    Nlocal = N.sum() # local number of particles
+    nonzero_cells = N.nonzero() # indices of nonzero cells
 
-    # the displacement field for all nonzero grid cells
-    offset = [displacement[i][pts[0], pts[1], pts[2]] for i in [0,1,2]]
+    # initialize the mesh of particle positions and velocity
+    # this has the shape: (number of dimensions, number of nonzero cells)
+    pos_mesh = numpy.empty(numpy.shape(nonzero_cells), dtype=delta.dtype)
+    vel_mesh = numpy.empty_like(pos_mesh)
     
-    # displace the coordinate mesh
-    x += offset[0]
-    y += offset[1]
-    z += offset[2]
-
+    # generate the coordinates for each nonzero cell
+    for i in range(delta.ndim): 
+        
+        # particle positions initially on the coordinate grid
+        pos_mesh[i] = numpy.squeeze(delta.pm.x[i])[nonzero_cells[i]]
+        
+        # velocity offsets for each particle
+        vel_mesh[i] = displacement[i][nonzero_cells]
+        
+        # displace the positions by the velocity offset
+        pos_mesh[i] += vel_mesh[i]
+        
     # convert displacement field to RSD
     # in Zel'dovich approx, RSD is implemented with an additional factor of (1+f)
     if f <= 0.:
@@ -284,30 +291,30 @@ def poisson_sample_to_points(delta, displacement, pm, nbar, f=0., bias=1., seed=
     
     # rank 0 computes the in-cell uniform offsets
     if comm.rank == 0:
-        dx = rng.uniform(0, H[0], size=Ntot)
-        dy = rng.uniform(0, H[1], size=Ntot)
-        dz = rng.uniform(0, H[2], size=Ntot)
+        in_cell_shift = numpy.empty((Ntot, delta.ndim), dtype=delta.dtype)
+        for i in range(delta.ndim):
+            in_cell_shift[:,i] = rng.uniform(0, H[i], size=Ntot)
     else:
-        dx = None; dy = None; dz = None
+        in_cell_shift = None
     
     # scatter the in-cell uniform offsets back to the ranks
-    counts = comm.allgather(Nlocal)    
-    dx = ScatterArray(dx, comm, root=0, counts=counts)
-    dy = ScatterArray(dy, comm, root=0, counts=counts)
-    dz = ScatterArray(dz, comm, root=0, counts=counts)
+    counts = comm.allgather(Nlocal) 
+    in_cell_shift = ScatterArray(in_cell_shift, comm, root=0, counts=counts)
+    
+    # initialize the output array of particle positions and velocity
+    # this has shape: (local number of particles, number of dimensions)
+    pos = numpy.empty((Nlocal, delta.ndim), dtype=delta.dtype)
+    vel = numpy.empty_like(pos)
     
     # coordinates of each object (placed randomly in each cell)
-    x = numpy.repeat(x, N[pts]) + dx
-    y = numpy.repeat(y, N[pts]) + dy
-    z = numpy.repeat(z, N[pts]) + dz
-    
-    for i in range(3):
-        offset[i] *= (1. + f)
-        offset[i] = numpy.repeat(offset[i], N[pts])
+    for i in range(delta.ndim):
+        pos[:,i] = numpy.repeat(pos_mesh[i], N[nonzero_cells]) + in_cell_shift[:,i]
+        pos[:,i] %= delta.BoxSize[i]
 
-    # enforce periodic and stack
-    x %= delta.BoxSize[0]
-    y %= delta.BoxSize[1]
-    z %= delta.BoxSize[2]
-    return numpy.vstack([x, y, z]).T, numpy.vstack(offset).T
+    # velocities of each object
+    for i in range(delta.ndim):
+        vel[:,i] *= (1. + f)
+        vel[:,i] = numpy.repeat(vel_mesh[i], N[nonzero_cells])
+
+    return pos, vel
   


### PR DESCRIPTION
addresses #288, although not completely. SlabIterator in its current form should only be used in 3D (hence, the "slab").  I think it mostly works in any dimension at the moment, but need to think about the non-singular plane and Hermitian weights. 

What did you have in mind for this, @rainwoodman ? Did you want to be able to do 1D and 2D Zel'dovich particles? Also, see rainwoodman/pmesh#17 for the case of 1D particle mesh
