### PR TITLE
Generalize Subsample datasource to read all columns of the hdf5 file.…

### DIFF
--- a/nbodykit/core/datasource/Subsample.py
+++ b/nbodykit/core/datasource/Subsample.py
@@ -54,14 +54,14 @@ class SubsampleDataSource(DataSource):
         dataset = h5py.File(self.path, mode='r')[self.dataset]
         data = dataset[...]
 
-        dtype = numpy.dtype([
-                ('Position', ('f4', 3)),
-                ('Velocity', ('f4', 3))
-                ])
+        dtype = data.dtype
         data2 = numpy.empty(len(data),dtype=dtype)
 
-        data2['Position'] = data['Position'] * self.BoxSize
-        data2['Velocity'] = data['Velocity'] * self.BoxSize
+        for col in data.dtype.names:
+            if col in ['Position', 'Velocity']:
+                data2[col] = data[col] * self.BoxSize
+            else:
+                data2[col] = data[col]
 
         nobj = (len(data2), len(data))
 


### PR DESCRIPTION
Just a small change so the Subsample datasource reads in all columns of the hdf5 file. Previously it only read Position and Velocity but skipped ID and potential other columns, which caused a crash when trying to take subsamples of subsamples because ID was not read.