### PR TITLE
cleaning up nightly build scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,8 @@ install:
     # base python setup
     - conda install --yes numpy=$NUMPY_VERSION nose cython mpi4py
     - conda install --yes h5py pandas scipy pytables pyyaml astropy numba dask sympy
-    #
-    # test optional HOD data sources
-    # - pip install halotools 
-    - pip install pfft-python kdcount mpsort pmesh sharedmem bigfile cachey --no-deps
-    - pip install https://github.com/bccp/abopt/archive/master.zip
+
+    - pip install --no-deps -r requirements.txt
     - pip install .
 
 script:

--- a/nersc/activate.sh
+++ b/nersc/activate.sh
@@ -2,15 +2,15 @@
 
 # can supply 0 or 1 argument
 if [ "$#" -gt 1 ]; then
-    echo "usage: activate.sh latest|stable"
+    echo "usage: activate.sh latest|stable|v2.0"
     exit 1
 fi
 
 # if no version provided, use 'stable'
 if [ $# -eq 0 ]; then
     version="stable"
-elif [[ "$1" -ne "stable" || "$1" -ne "latest" ]]; then
-    echo "valid version names are 'stable' and 'latest'"
+elif [[ "$1" != "stable" && "$1" != "latest" && "$1" != "v2.0" ]]; then
+    echo "valid version names: 'stable', 'latest', 'v2.0'"
     exit 1
 else
     version=$1
@@ -22,7 +22,7 @@ elif [[ -n $ZSH_VERSION ]]; then
     _SCRIPT_LOCATION=${funcstack[1]}
 else
     echo "Only bash and zsh are supported"
-    return 1
+    exit 1
 fi
 
 NBKITROOT=`dirname ${_SCRIPT_LOCATION}`
@@ -52,6 +52,10 @@ function srun-nbkit {
         np="-n $1"
         shift
     fi
-    srun $np python-mpi /dev/shm/local/bin/nbkit.py $*
+    if [[ "$version" != "v2.0" ]]; then
+        srun $np python-mpi /dev/shm/local/bin/nbkit.py $*
+    else
+        echo "calling 'nbkit.py' is deprecated!"
+        return 1
+    fi
 }
-

--- a/nersc/build_requirements.txt
+++ b/nersc/build_requirements.txt
@@ -1,0 +1,11 @@
+numpy
+nose 
+cython 
+mpi4py 
+h5py 
+pandas 
+scipy 
+pytables 
+pyyaml 
+astropy 
+numba

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@ pfft-python
 kdcount
 mpsort
 bigfile
+dask>=0.13
+cachey
+halotools>=0.4
+


### PR DESCRIPTION
This is in preparation for handling different versions on nersc:

* nightly build script activates conda environments for python 2.7, 3.5 stored in  `/usr/common/contrib/bccp/nbodykit/build-envs/2.7-nbodykit-base`. These were created from the new `build_requirements.txt` file. This avoids a bunch of potential conflicts with the base anaconda distributions when installing dependencies
* the `activate.sh` script now recognizes `v2.0` as an option (`stable` and `latest` stay the same for now)
* cleaned up the Travis dependencies, let's see if I broke anything