### PR TITLE
Add a value to to_mesh.

### DIFF
--- a/nbodykit/base/catalog.py
+++ b/nbodykit/base/catalog.py
@@ -301,6 +301,18 @@ class CatalogSource(object):
         """
         return ConstantArray(1.0, self.size, chunks=100000)
 
+    @column
+    def Value(self):
+        """
+        When interpolating a CatalogSource on to a mesh, the value of this
+        array is used as the Value that each particle contributes to a given
+        mesh cell. The mesh field is a weighted average of Value.
+
+        By default, this array is set to unity for all particles
+        """
+        return ConstantArray(1.0, self.size, chunks=100000)
+
+
     def get_hardcolumn(self, col):
         """
         Construct and return a hard-coded column. These are usually produced by calling
@@ -444,7 +456,7 @@ class CatalogSource(object):
 
     def to_mesh(self, Nmesh=None, BoxSize=None, dtype='f4',
                 interlaced=False, compensated=False, window='cic',
-                weight='Weight', selection='Selection'):
+                weight='Weight', value='Value', selection='Selection'):
         """
         Convert the CatalogSource to a MeshSource
 
@@ -470,6 +482,8 @@ class CatalogSource(object):
             see `pmesh.window.methods`
         weight : str, optional
             the name of the column specifying the weight for each particle
+        value: str, optional
+            the name of the column specifying the field value for each particle
         selection : str, optional
             the name of the column that specifies which (if any) slice
             of the CatalogSource to take
@@ -507,7 +521,7 @@ class CatalogSource(object):
                                   "does not define one in 'attrs'."))
 
         r = CatalogMeshSource(self, Nmesh=Nmesh, BoxSize=BoxSize,
-                                dtype=dtype, weight=weight, selection=selection)
+                                dtype=dtype, weight=weight, value=value, selection=selection)
         r.interlaced = interlaced
         r.compensated = compensated
         r.window = window

--- a/nbodykit/base/catalogmesh.py
+++ b/nbodykit/base/catalogmesh.py
@@ -155,6 +155,7 @@ class CatalogMeshSource(MeshSource, CatalogSource):
                 lay = pm.decompose(position, smoothing=1.0 * paintbrush.support)
                 p = lay.exchange(position)
                 w = lay.exchange(weight)
+                v = lay.exchange(value)
 
                 H = pm.BoxSize / pm.Nmesh
 

--- a/nbodykit/source/catalog/fkp.py
+++ b/nbodykit/source/catalog/fkp.py
@@ -24,7 +24,7 @@ class FKPMeshSource(CatalogMeshSource):
         self.fkp_weight  = fkp_weight
         self.nbar        = nbar
 
-        CatalogMeshSource.__init__(self, source, BoxSize, Nmesh, dtype, weight, selection)
+        CatalogMeshSource.__init__(self, source, BoxSize, Nmesh, dtype, weight, 'Value', selection)
 
     @contextlib.contextmanager
     def _set_mesh(self, prefix):
@@ -48,12 +48,14 @@ class FKPMeshSource(CatalogMeshSource):
         self.position  = prefix+'.'+pos
         self.weight    = prefix+'.'+weight
         self.selection = prefix+'.'+sel
+        self.value = prefix+'.'+'Value'
         yield
 
         # restore
         self.position  = pos
         self.weight    = weight
         self.selection = sel
+        self.value = 'Value'
 
     def to_real_field(self):
         """


### PR DESCRIPTION
There are two types of weights.

The original 'weight' stands for the effective number of particles.
The second weight, 'Value' stands for the field that we are averaging.

This is crucial for dealing with multiple particle species (and masses).
We revealed the issue when Biwei was looking at hydro simulations with nbodykit.