### PR TITLE
Fix len() error on dask array with ConstantArray of size 1.

### DIFF
--- a/nbodykit/tests/test_transform.py
+++ b/nbodykit/tests/test_transform.py
@@ -80,7 +80,14 @@ def test_combine(comm):
     with pytest.raises(ValueError):
         cat = transform.ConcatenateSources(s1, s2, columns='InvalidColumn')
 
-@MPITest([1, 4])
+@MPITest([1])
 def test_constarray(comm):
-    a = ConstantArray(1.0, 1, chunks=100000)
+    a = ConstantArray(1.0, 1, chunks=1000)
     assert len(a) == 1
+    print(a.shape)
+    assert a.shape == (1,)
+    a = ConstantArray([1.0, 1.0], 1, chunks=1000)
+    assert a.shape == (1, 2)
+
+    a = ConstantArray([1.0, 1.0], 3, chunks=1000)
+    assert a.shape == (3, 2)

--- a/nbodykit/tests/test_transform.py
+++ b/nbodykit/tests/test_transform.py
@@ -1,7 +1,7 @@
 from runtests.mpi import MPITest
 from nbodykit.lab import *
 from nbodykit import setup_logging
-
+from nbodykit.transform import ConstantArray
 import pytest
 
 # debug logging
@@ -79,3 +79,8 @@ def test_combine(comm):
     # fail on invalid column
     with pytest.raises(ValueError):
         cat = transform.ConcatenateSources(s1, s2, columns='InvalidColumn')
+
+@MPITest([1, 4])
+def test_constarray(comm):
+    a = ConstantArray(1.0, 1, chunks=100000)
+    assert len(a) == 1

--- a/nbodykit/transform.py
+++ b/nbodykit/transform.py
@@ -109,9 +109,9 @@ def ConstantArray(value, size, chunks=100000):
     chunks : int, optional
         the size of the dask array chunks
     """
-    toret = numpy.array(value)
-    toret = numpy.lib.stride_tricks.as_strided(toret, (size, toret.size), (0, toret.itemsize))
-    return da.from_array(toret.squeeze(), chunks=chunks)
+    ele = numpy.array(value)
+    toret = numpy.lib.stride_tricks.as_strided(ele, [size] + list(ele.shape), [0] + list(ele.strides))
+    return da.from_array(toret, chunks=chunks)
 
 
 def SkyToUnitSphere(ra, dec, degrees=True):
@@ -135,7 +135,7 @@ def SkyToUnitSphere(ra, dec, degrees=True):
         ``x``, ``y``, and ``z``
 
     Raises
-    ------
+   ------
     TypeError
         If the input columns are not dask arrays
     """


### PR DESCRIPTION
This can be triggered when we generate an empty FOF catalog, and saving it to disk. The Selection column is a ConstantArray of size 1. But the squeeze method makes it a scalar -- which has no well defined __len__ in dask. This PR removes the squeeze