### PR TITLE
FOF gives unstable results at lower number of ranks

### DIFF
--- a/nbodykit/algorithms/fof.py
+++ b/nbodykit/algorithms/fof.py
@@ -271,7 +271,7 @@ def _fof_local(layout, pos, boxsize, ll, comm):
     N = len(pos)
 
     pos = layout.exchange(pos)
-    data = cluster.dataset(pos, boxsize=boxsize)
+    data = cluster.dataset(pos % boxsize, boxsize=boxsize)
     fof = cluster.fof(data, linking_length=ll, np=0)
     labels = fof.labels
     del fof

--- a/nbodykit/algorithms/fof.py
+++ b/nbodykit/algorithms/fof.py
@@ -272,7 +272,6 @@ def _fof_local(layout, pos, boxsize, ll, comm):
 
     pos = layout.exchange(pos)
     data = cluster.dataset(pos, boxsize=boxsize)
-
     fof = cluster.fof(data, linking_length=ll, np=0)
     labels = fof.labels
     del fof
@@ -349,6 +348,9 @@ def fof(source, linking_length, comm):
     BoxSize = source.attrs.get('BoxSize', None)
     if BoxSize is None:
         raise ValueError("cannot compute FOF clustering of source without 'BoxSize' in ``attrs`` dict")
+
+    if numpy.isscalar(BoxSize):
+        BoxSize = [BoxSize, BoxSize, BoxSize]
 
     grid = [
         numpy.linspace(0, BoxSize[0], np[0] + 1, endpoint=True),

--- a/nbodykit/algorithms/tests/test_fof.py
+++ b/nbodykit/algorithms/tests/test_fof.py
@@ -2,6 +2,8 @@ from runtests.mpi import MPITest
 from nbodykit.lab import *
 from nbodykit import setup_logging
 
+from numpy.testing import assert_allclose
+
 # debug logging
 setup_logging("debug")
 
@@ -22,3 +24,39 @@ def test_fof(comm):
     # save the halos
     peaks = fof.find_features(peakcolumn='Density')
     peaks.save("FOF-%d" % comm.size, ['CMPosition', 'CMVelocity', 'Length', 'PeakPosition', 'PeakVelocity'])
+
+@MPITest([1, 4])
+def test_fof_parallel_no_merge(comm):
+    CurrentMPIComm.set(comm)
+    from pmesh.pm import ParticleMesh
+    pm = ParticleMesh(BoxSize=[8, 8, 8], Nmesh=[8, 8, 8], comm=comm)
+    Q = pm.generate_uniform_particle_grid()
+    cat = ArrayCatalog({'Position' : Q}, BoxSize=pm.BoxSize, Nmesh=pm.Nmesh)
+
+    fof = FOF(cat, linking_length=0.9, nmin=0)
+    
+    labels = numpy.concatenate(comm.allgather((fof.labels)), axis=0)
+    # one particle per group
+    assert max(labels) == cat.csize - 1
+
+@MPITest([1, 4])
+def test_fof_parallel_merge(comm):
+    CurrentMPIComm.set(comm)
+    from pmesh.pm import ParticleMesh
+    pm = ParticleMesh(BoxSize=[32, 32, 32], Nmesh=[32, 32, 32], comm=comm)
+    Q = pm.generate_uniform_particle_grid(shift=0)
+    Q1 = Q.copy()
+    Q1[:] += 0.01
+    Q2 = Q.copy()
+    Q2[:] -= 0.01
+    Q3 = Q.copy()
+    Q3[:] += 0.02
+    cat = ArrayCatalog({'Position' : 
+            numpy.concatenate([Q, Q1, Q2, Q3], axis=0)}, BoxSize=pm.BoxSize, Nmesh=pm.Nmesh)
+
+    fof = FOF(cat, linking_length=0.011 * 3 ** 0.5, nmin=0, absolute=True)
+
+    labels = numpy.concatenate(comm.allgather((fof.labels)), axis=0)
+    assert max(labels) == pm.Nmesh.prod() - 1
+    assert all(numpy.bincount(labels) == 4)
+


### PR DESCRIPTION
FOF used to give unstable results when the boxsize is close to the size of domain and there are particles outside of the box.

I do not have an isolated test case but this seems to be related to the failure of a test case in fastpm-python.
The labels of a halo found from 4 ranks is broken into several when running with 1 rank.
However,  run with 1 rank without periodic boundary these particles become 1 halo. 
After adding the wrapping into the boundary these particles become 1 halo on a single rank as well.