### PR TITLE
Adding Non-periodic support to FOF.

### DIFF
--- a/nbodykit/algorithms/fof.py
+++ b/nbodykit/algorithms/fof.py
@@ -351,19 +351,19 @@ def fof(source, linking_length, comm, periodic):
 
     np = split_size_3d(comm.size)
 
-    BoxSize = source.attrs.get('BoxSize', None)
-
-    if BoxSize is None:
-        if periodic:
+    if periodic:
+        BoxSize = source.attrs.get('BoxSize', None)
+        if BoxSize is None:
             raise ValueError("cannot compute FOF clustering of source without 'BoxSize' in ``attrs`` dict")
-        else:
-            left = source['Position'].min(axis=0).compute()
-            right = source['Position'].max(axis=0).compute()
-    else:
         if numpy.isscalar(BoxSize):
             BoxSize = [BoxSize, BoxSize, BoxSize]
+
         left = [0, 0, 0]
         right = BoxSize
+    else:
+        BoxSize = None
+        left = numpy.min(comm.allgather(source['Position'].min(axis=0).compute()), axis=0)
+        right = numpy.max(comm.allgather(source['Position'].max(axis=0).compute()), axis=0)
 
     grid = [
         numpy.linspace(left[0], right[0], np[0] + 1, endpoint=True),

--- a/nbodykit/algorithms/fof.py
+++ b/nbodykit/algorithms/fof.py
@@ -42,7 +42,7 @@ class FOF(object):
     """
     logger = logging.getLogger('FOF')
 
-    def __init__(self, source, linking_length, nmin, absolute=False):
+    def __init__(self, source, linking_length, nmin, absolute=False, periodic=True):
 
         self.comm = source.comm
         self._source = source
@@ -54,6 +54,10 @@ class FOF(object):
         self.attrs['linking_length'] = linking_length
         self.attrs['nmin'] = nmin
         self.attrs['absolute'] = absolute
+        self.attrs['periodic'] = periodic
+
+        if periodic and 'BoxSize' not in source.attrs:
+            raise ValueError("Periodic FOF requires BoxSize in .attrs['BoxSize']")
 
         # linking length relative to mean separation
         if not absolute:
@@ -85,7 +89,7 @@ class FOF(object):
             number of FOF halos found
         """
         # run the FOF
-        minid = fof(self._source, self._linking_length, self.comm)
+        minid = fof(self._source, self._linking_length, self.comm, self.attrs['periodic'])
 
         # the sorted labels
         self.labels = _assign_labels(minid, comm=self.comm, thresh=self.attrs['nmin'])
@@ -110,7 +114,7 @@ class FOF(object):
             also included if ``peakcolumn`` is not None
         """
         # the center-of-mass (Position, Velocity, Length)
-        halos = fof_catalog(self._source, self.labels, self.comm, peakcolumn=peakcolumn)
+        halos = fof_catalog(self._source, self.labels, self.comm, peakcolumn=peakcolumn, periodic=self.attrs['periodic'])
         attrs = self._source.attrs.copy()
         attrs.update(self.attrs)
         return ArrayCatalog(halos, comm=self.comm, **attrs)
@@ -167,7 +171,7 @@ class FOF(object):
             peakcolumn = None
         else:
             pass
-        data = fof_catalog(self._source, self.labels, self.comm, peakcolumn=peakcolumn)
+        data = fof_catalog(self._source, self.labels, self.comm, peakcolumn=peakcolumn, periodic=self.attrs['periodic'])
         data = data[data['Length'] > 0]
         halos = ArrayCatalog(data, **attrs)
         if posdef == 'cm':
@@ -271,7 +275,9 @@ def _fof_local(layout, pos, boxsize, ll, comm):
     N = len(pos)
 
     pos = layout.exchange(pos)
-    data = cluster.dataset(pos % boxsize, boxsize=boxsize)
+    if boxsize is not None:
+        pos %= boxsize
+    data = cluster.dataset(pos, boxsize=boxsize)
     fof = cluster.fof(data, linking_length=ll, np=0)
     labels = fof.labels
     del fof
@@ -313,7 +319,7 @@ def _fof_merge(layout, minid, comm):
     minid = layout.gather(minid, mode=numpy.fmin)
     return minid
 
-def fof(source, linking_length, comm):
+def fof(source, linking_length, comm, periodic):
     """
     Run Friends-of-friends halo finder.
 
@@ -346,18 +352,25 @@ def fof(source, linking_length, comm):
     np = split_size_3d(comm.size)
 
     BoxSize = source.attrs.get('BoxSize', None)
-    if BoxSize is None:
-        raise ValueError("cannot compute FOF clustering of source without 'BoxSize' in ``attrs`` dict")
 
-    if numpy.isscalar(BoxSize):
-        BoxSize = [BoxSize, BoxSize, BoxSize]
+    if BoxSize is None:
+        if periodic:
+            raise ValueError("cannot compute FOF clustering of source without 'BoxSize' in ``attrs`` dict")
+        else:
+            left = source['Position'].min(axis=0).compute()
+            right = source['Position'].max(axis=0).compute()
+    else:
+        if numpy.isscalar(BoxSize):
+            BoxSize = [BoxSize, BoxSize, BoxSize]
+        left = [0, 0, 0]
+        right = BoxSize
 
     grid = [
-        numpy.linspace(0, BoxSize[0], np[0] + 1, endpoint=True),
-        numpy.linspace(0, BoxSize[1], np[1] + 1, endpoint=True),
-        numpy.linspace(0, BoxSize[2], np[2] + 1, endpoint=True),
+        numpy.linspace(left[0], right[0], np[0] + 1, endpoint=True),
+        numpy.linspace(left[1], right[1], np[1] + 1, endpoint=True),
+        numpy.linspace(left[2], right[2], np[2] + 1, endpoint=True),
     ]
-    domain = GridND(grid, comm=comm)
+    domain = GridND(grid, comm=comm, periodic=periodic)
 
     Position = source.compute(source['Position'])
     layout = domain.decompose(Position, smoothing=linking_length * 1)
@@ -384,7 +397,7 @@ def fof_find_peaks(source, label, comm,
 
 def fof_catalog(source, label, comm,
                 position='Position', velocity='Velocity', initposition='InitialPosition',
-                peakcolumn=None):
+                peakcolumn=None, periodic=True):
     """
     Catalog of FOF groups based on label from a parent source
 
@@ -436,14 +449,16 @@ def fof_catalog(source, label, comm,
     dtype=[('CMPosition', ('f4', 3)),('CMVelocity', ('f4', 3)),('Length', 'i4')]
     N = count(label, comm=comm)
 
-    # make sure BoxSize is there
-    BoxSize = source.attrs.get('BoxSize', None)
-    if BoxSize is None:
-        raise ValueError("cannot compute halo catalog from source without 'BoxSize' in ``attrs`` dict")
+    if periodic:
+        # make sure BoxSize is there
+        boxsize = source.attrs.get('BoxSize', None)
+        if boxsize is None:
+            raise ValueError("cannot compute halo catalog from source without 'BoxSize' in ``attrs`` dict")
+    else:
+        boxsize = None
 
     # center of mass position
-    hpos = centerofmass(label, source.compute(source[position])/BoxSize, boxsize=1.0, comm=comm)
-    hpos *= BoxSize
+    hpos = centerofmass(label, source.compute(source[position]), boxsize=boxsize, comm=comm)
 
     # center of mass velocity
     hvel = centerofmass(label, source.compute(source[velocity]), boxsize=None, comm=comm)
@@ -451,8 +466,8 @@ def fof_catalog(source, label, comm,
     # center of mass initial position
     if initposition in source:
         dtype.append(('InitialPosition', ('f4', 3)))
-        hpos_init = centerofmass(label, source.compute(source[initposition])/BoxSize, boxsize=1.0, comm=comm)
-        hpos_init *= BoxSize
+        hpos_init = centerofmass(label, source.compute(source[initposition]), boxsize=boxsize, comm=comm)
+        hpos_init
 
     if peakcolumn is not None:
         assert peakcolumn in source
@@ -467,8 +482,7 @@ def fof_catalog(source, label, comm,
         label1 = label * (density >= dmax[label])
 
         # compute the center of mass on the new labels
-        ppos = centerofmass(label1, source.compute(source[position])/BoxSize, boxsize=1.0, comm=comm)
-        ppos *= BoxSize
+        ppos = centerofmass(label1, source.compute(source[position]), boxsize=boxsize, comm=comm)
         pvel = centerofmass(label1, source.compute(source[velocity]), boxsize=None, comm=comm)
 
     dtype = numpy.dtype(dtype)
@@ -818,7 +832,7 @@ class LinearTopology(object):
         next = heads[self.comm.rank + 1]
         return next
 
-def centerofmass(label, pos, boxsize=1.0, comm=MPI.COMM_WORLD):
+def centerofmass(label, pos, boxsize, comm=MPI.COMM_WORLD):
     """
     Calulate the center of mass of particles of the same label.
 
@@ -855,9 +869,10 @@ def centerofmass(label, pos, boxsize=1.0, comm=MPI.COMM_WORLD):
                         minlength=len(N))
         comm.Allreduce(MPI.IN_PLACE, posmin, op=MPI.MIN)
         dpos = pos - posmin[label]
-        bhalf = boxsize * 0.5
-        dpos[dpos < -bhalf] += boxsize
-        dpos[dpos >= bhalf] -= boxsize
+        for i in range(dpos.shape[-1]):
+            bhalf = boxsize[i] * 0.5
+            dpos[..., i][dpos[..., i] < -bhalf] += boxsize[i]
+            dpos[..., i][dpos[..., i] >= bhalf] -= boxsize[i]
     else:
         dpos = pos
     dpos = equiv_class(label, dpos, op=numpy.add, dense_labels=True, minlength=len(N))
@@ -865,7 +880,7 @@ def centerofmass(label, pos, boxsize=1.0, comm=MPI.COMM_WORLD):
     comm.Allreduce(MPI.IN_PLACE, dpos, op=MPI.SUM)
     dpos /= N[:, None]
 
-    if boxsize:
+    if boxsize is not None:
         hpos = posmin + dpos
         hpos %= boxsize
     else:


### PR DESCRIPTION
This addresses #417, where a boxsize is absurdly required for a non-periodic dataset. I guess in other places of the code we still mostly assume periodic boundary. I wonder if this simplifies the FiberAssignment algorithm?