### PR TITLE
I suggest not using latex

### DIFF
--- a/nbodykit/style/notebook.mplstyle
+++ b/nbodykit/style/notebook.mplstyle
@@ -2,7 +2,7 @@ figure.figsize: 12, 7
 figure.edgecolor: white
 figure.facecolor: white
 
-text.usetex: True
+text.usetex: False
 
 lines.linewidth: 2.5
 lines.markeredgewidth: 0


### PR DESCRIPTION
It is not always properly installed on the target system. For example jupyter-dev.nersc.gov has a crippled latex and causes the notebook to fail to run. Does the font look very bad without using Tex?