### PR TITLE
Allow automatic discovery of header from a BigFile.

### DIFF
--- a/nbodykit/io/tests/test_bigfile.py
+++ b/nbodykit/io/tests/test_bigfile.py
@@ -34,17 +34,23 @@ def temporary_data():
 def test_data(comm):
 
     with temporary_data() as (data, tmpfile):
-        
         # read
         ff = BigFile(tmpfile, header='Header')
-        
+
         # check size
         assert ff.attrs['Size'] == 1024
-        
+
         # and data
         numpy.testing.assert_almost_equal(data['Position'], ff['Position'][:])
         numpy.testing.assert_almost_equal(data['Velocity'], ff['Velocity'][:])
 
+@MPITest([1])
+def test_data_auto_header(comm):
+    with temporary_data() as (data, tmpfile):
+        ff = BigFile(tmpfile)
+
+        # check size
+        assert ff.attrs['Size'] == 1024
 
 @MPITest([1])
 def test_pickle(comm):


### PR DESCRIPTION
This improves the usability of reading a saved catalog.
A saved catalog saves the attrs in Header column, but when we
read it in from BigFileCatalog the default was not to use
that column, creating confusions.

Original email report of the issue:
```
I’m having some difficulty saving and reading files using CatalogSource. I have a simple script like below to save the ArrayCatalog data:

    # create the catalogue
    particle_data = {}
    particle_data['Position'] = pos
    particle_data['Velocity'] = vel
    particle_data['ID'] = Id
    cat = NBlab.ArrayCatalog(particle_data, BoxSize=header['boxsize'])
    cat.save(dir+’/Matter', ["Position", "Velocity"])

This saves everything nicely into the Matter directory. But Later when I try to read in this data using something like
cat = BigFileCatalog(‘Matter’)
I get the following: “Error: Dataset length is inconsistent on Position“

Is there something I need to specify in the save command in order for me to properly read the data in using BigFileCatalog?
```