### PR TITLE
FFTCorr

### DIFF
--- a/nbodykit/algorithms/__init__.py
+++ b/nbodykit/algorithms/__init__.py
@@ -1,4 +1,5 @@
 from .fftpower import FFTPower, ProjectedFFTPower
+from .fftcorr import FFTCorr
 from .kdtree import KDDensity
 from .fof import FOF
 from .convpower import ConvolvedFFTPower
@@ -10,6 +11,7 @@ from .survey_paircount import SurveyDataPairCount, AngularPairCount
 from .cgm import CylindricalGroups
 
 __all__ = ['FFTPower', 'ProjectedFFTPower',
+           'FFTCorr',
            'KDDensity',
            'FOF',
            'ConvolvedFFTPower',

--- a/nbodykit/algorithms/fftcorr.py
+++ b/nbodykit/algorithms/fftcorr.py
@@ -1,0 +1,228 @@
+import os
+import numpy
+import logging
+
+from nbodykit import CurrentMPIComm
+from nbodykit.binned_statistic import BinnedStatistic
+from nbodykit.meshtools import SlabIterator
+from nbodykit.base.catalog import CatalogSourceBase
+from nbodykit.base.mesh import MeshSource
+from nbodykit.base.catalogmesh import CatalogMesh
+
+from .fftpower import FFTBase
+from .fftpower import project_to_basis
+
+class FFTCorr(FFTBase):
+    r"""
+    Algorithm to compute the 1d or 2d correlation and/or multipoles
+    in a periodic box, using a Fast Fourier Transform (FFT).
+
+    This computes the power spectrum as the square of the Fourier modes of the
+    density field, which are computed via a FFT. Then it is transformed back
+    to obtain the correlation function.
+
+    Results are computed when the object is inititalized. See the documenation
+    of :func:`~FFTCorr.run` for the attributes storing the results.
+
+    .. note::
+        This is very similar to :class:`~FFTPower`. 
+
+    Parameters
+    ----------
+    first : CatalogSource, MeshSource
+        the source for the first field; if a CatalogSource is provided, it
+        is automatically converted to MeshSource using the default painting
+        parameters (via :func:`~nbodykit.base.catalogmesh.CatalogMesh.to_mesh`)
+    mode : {'1d', '2d'}
+        compute either 1d or 2d power spectra
+    Nmesh : int, optional
+        the number of cells per side in the particle mesh used to paint the source
+    BoxSize : int, 3-vector, optional
+        the size of the box
+    second : CatalogSource, MeshSource, optional
+        the second source for cross-correlations
+    los : array_like , optional
+        the direction to use as the line-of-sight; must be a unit vector
+    Nmu : int, optional
+        the number of mu bins to use from :math:`\mu=[0,1]`;
+        if `mode = 1d`, then ``Nmu`` is set to 1
+    dr : float, optional
+        the linear spacing of ``r`` bins to use; if not provided, the
+        fundamental mode  of the box is used
+    rmin : float, optional
+        the lower edge of the first ``r`` bin to use
+    poles : list of int, optional
+        a list of multipole numbers ``ell`` to compute :math:`\xi_\ell(r)`
+        from :math:`\xi(r,\mu)`
+    """
+    logger = logging.getLogger('FFTCorr')
+
+    def __init__(self, first, mode, Nmesh=None, BoxSize=None, second=None,
+                    los=[0, 0, 1], Nmu=5, dr=None, rmin=0., poles=[]):
+
+        # mode is either '1d' or '2d'
+        if mode not in ['1d', '2d']:
+            raise ValueError("`mode` should be either '1d' or '2d'")
+
+        if poles is None:
+            poles = []
+
+        # check los
+        if numpy.isscalar(los) or len(los) != 3:
+            raise ValueError("line-of-sight ``los`` should be vector with length 3")
+        if not numpy.allclose(numpy.einsum('i,i', los, los), 1.0, rtol=1e-5):
+            raise ValueError("line-of-sight ``los`` must be a unit vector")
+
+        FFTBase.__init__(self, first, second, Nmesh, BoxSize)
+
+        # save meta-data
+        self.attrs['mode'] = mode
+        self.attrs['los'] = los
+        self.attrs['Nmu'] = Nmu
+        self.attrs['poles'] = poles
+
+        if dr is None:
+            dr = self.attrs['BoxSize'].min() / self.attrs['Nmesh'].max()
+
+        self.attrs['dr'] = dr
+        self.attrs['rmin'] = rmin
+
+        self.run()
+
+    def run(self):
+        r"""
+        Compute the correlation function in a periodic box, using FFTs. This
+        function returns nothing, but attaches several attributes
+        to the class:
+
+        - :attr:`edges`
+        - :attr:`corr`
+        - :attr:`poles`
+
+        Attributes
+        ----------
+        edges : array_like
+            the edges of the wavenumber bins
+        corr : :class:`~nbodykit.binned_statistic.BinnedStatistic`
+            a BinnedStatistic object that holds the measured :math:`\xi(r)` or
+            :math:`\xi(r,\mu)`. It stores the following variables:
+
+            - r :
+                the mean value for each ``r`` bin
+            - mu : ``mode=2d`` only
+                the mean value for each ``mu`` bin
+            - corr :
+                real array storing the correlation function
+            - modes :
+                the number of modes averaged together in each bin
+
+        poles : :class:`~nbodykit.binned_statistic.BinnedStatistic` or ``None``
+            a BinnedStatistic object to hold the multipole results
+            :math:`\xi_\ell(r)`; if no multipoles were requested by the user,
+            this is ``None``. It stores the following variables:
+
+            - r :
+                the mean value for each ``r`` bin
+            - power_L :
+                complex array storing the real and imaginary components for
+                the :math:`\ell=L` multipole
+            - modes :
+                the number of modes averaged together in each bin
+
+        attrs : dict
+            dictionary of meta-data; in addition to storing the input parameters,
+            it includes the following fields computed during the algorithm
+            execution:
+
+            - shotnoise : float
+                the power Poisson shot noise, equal to :math:`V/N`, where
+                :math:`V` is the volume of the box and `N` is the total
+                number of objects; if a cross-correlation is computed, this
+                will be equal to zero
+            - N1 : int
+                the total number of objects in the first source
+            - N2 : int
+                the total number of objects in the second source
+        """
+
+        # only need one mu bin if 1d case is requested
+        if self.attrs['mode'] == "1d": self.attrs['Nmu'] = 1
+
+        # measure the 3D power (y3d is a ComplexField)
+        y3d = self._compute_3d_power()
+
+        # measure the 3D correlation (y3d is a RealField)
+        y3d = y3d.c2r(out=Ellipsis)
+
+        # correlation is dimensionless
+        # Note that L^3 cancels with dk^3.
+        y3d[...] *= 1.0 / y3d.BoxSize.prod()
+
+        # binning in k out to the minimum nyquist frequency
+        # (accounting for possibly anisotropic box)
+        dr = self.attrs['dr']
+        rmin = self.attrs['rmin']
+        redges = numpy.arange(rmin, 0.5 * y3d.BoxSize.min() + dr/2, dr)
+
+        # project on to the desired basis
+        muedges = numpy.linspace(0, 1, self.attrs['Nmu']+1, endpoint=True)
+        edges = [redges, muedges]
+        result, pole_result = project_to_basis(y3d, edges,
+                                               poles=self.attrs['poles'],
+                                               los=self.attrs['los'])
+
+        # format the corr results into structured array
+        if self.attrs['mode'] == "1d":
+            cols = ['r', 'corr', 'modes']
+            icols = [0, 2, 3]
+            edges = edges[0]
+        else:
+            cols = ['r', 'mu', 'corr', 'modes']
+            icols = [0, 1, 2, 3]
+
+        # corr results as a structured array
+        dtype = numpy.dtype([(name, result[icol].dtype.str) for icol,name in zip(icols,cols)])
+        corr = numpy.squeeze(numpy.empty(result[0].shape, dtype=dtype))
+        for icol, col in zip(icols, cols):
+            corr[col][:] = numpy.squeeze(result[icol])
+
+        # multipole results as a structured array
+        poles = None
+        if pole_result is not None:
+            r, poles, N = pole_result
+            cols = ['r'] + ['corr_%d' %l for l in self.attrs['poles']] + ['modes']
+            result = [r] + [pole for pole in poles] + [N]
+
+            dtype = numpy.dtype([(name, result[icol].dtype.str) for icol,name in enumerate(cols)])
+            poles = numpy.empty(result[0].shape, dtype=dtype)
+            for icol, col in enumerate(cols):
+                poles[col][:] = result[icol]
+
+        # set all the necessary results
+        self.edges = edges
+        self.poles = poles
+        self.corr = corr
+
+        self._make_datasets()
+
+    def __getstate__(self):
+        state = dict(
+                     edges=self.edges,
+                     corr=self.corr.data,
+                     poles=getattr(self.poles, 'data', None),
+                     attrs=self.attrs)
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._make_datasets()
+
+    def _make_datasets(self):
+
+        if self.attrs['mode'] == '1d':
+            self.corr = BinnedStatistic(['r'], [self.edges], self.corr, fields_to_sum=['modes'], **self.attrs)
+        else:
+            self.corr = BinnedStatistic(['r', 'mu'], self.edges, self.corr, fields_to_sum=['modes'], **self.attrs)
+        if self.poles is not None:
+            self.poles = BinnedStatistic(['r'], [self.corr.edges['r']], self.poles, fields_to_sum=['modes'], **self.attrs)
+

--- a/nbodykit/algorithms/fftpower.py
+++ b/nbodykit/algorithms/fftpower.py
@@ -9,7 +9,7 @@ from nbodykit.base.catalog import CatalogSourceBase
 from nbodykit.base.mesh import MeshSource
 from nbodykit.base.catalogmesh import CatalogMesh
 
-class FFTPowerBase(object):
+class FFTBase(object):
     """
     Base class provides functions for periodic FFT based Power spectrum code
 
@@ -97,7 +97,59 @@ class FFTPowerBase(object):
 
         return self
 
-class FFTPower(FFTPowerBase):
+    def _compute_3d_power(self):
+        """
+        Compute and return the 3D power from two input sources
+
+        Returns
+        -------
+        p3d : array_like (complex)
+            the 3D complex array holding the power spectrum
+        """
+        c1 = self.first.paint(mode='complex', Nmesh=self.attrs['Nmesh'])
+
+        # compute the auto power of single supplied field
+        if self.first is self.second:
+            c2 = c1
+        else:
+            c2 = self.second.paint(mode='complex', Nmesh=self.attrs['Nmesh'])
+
+        # calculate the 3d power spectrum, slab-by-slab to save memory
+        p3d = c1
+        for (s0, s1, s2) in zip(p3d.slabs, c1.slabs, c2.slabs):
+            s0[...] = s1 * s2.conj()
+
+        for i, s0 in zip(p3d.slabs.i, p3d.slabs):
+            # clear the zero mode.
+            mask = True
+            for i1 in i:
+                mask = mask & (i1 == 0)
+            s0[mask] = 0
+
+        # the complex field is dimensionless; power is L^3
+        # ref to http://icc.dur.ac.uk/~tt/Lectures/UA/L4/cosmology.pdf
+        p3d[...] *= self.attrs['BoxSize'].prod()
+
+        # get the number of objects (in a safe manner)
+        N1 = c1.attrs.get('N', 0)
+        N2 = c2.attrs.get('N', 0)
+        self.attrs.update({'N1':N1, 'N2':N2})
+
+        # add shotnoise (nonzero only for auto-spectra)
+        Pshot = 0
+        if self.first is self.second:
+            if 'shotnoise' not in c1.attrs:
+                if isinstance(self.first, CatalogMesh):
+                    import warnings
+                    warnings.warn(("no 'shotnoise' found for auto power spectrum "
+                                   "of discrete data in FFTPower"))
+            else:
+                Pshot = c1.attrs['shotnoise']
+        self.attrs['shotnoise'] = Pshot
+
+        return p3d
+
+class FFTPower(FFTBase):
     """
     Algorithm to compute the 1d or 2d power spectrum and/or multipoles
     in a periodic box, using a Fast Fourier Transform (FFT).
@@ -158,7 +210,7 @@ class FFTPower(FFTPowerBase):
         if not numpy.allclose(numpy.einsum('i,i', los, los), 1.0, rtol=1e-5):
             raise ValueError("line-of-sight ``los`` must be a unit vector")
 
-        FFTPowerBase.__init__(self, first, second, Nmesh, BoxSize)
+        FFTBase.__init__(self, first, second, Nmesh, BoxSize)
 
         # save meta-data
         self.attrs['mode'] = mode
@@ -356,7 +408,7 @@ class FFTPower(FFTPowerBase):
 
         return p3d
 
-class ProjectedFFTPower(FFTPowerBase):
+class ProjectedFFTPower(FFTBase):
     """
     The power spectrum of a field in a periodic box, projected over certain axes.
 
@@ -396,7 +448,7 @@ class ProjectedFFTPower(FFTPowerBase):
     def __init__(self, first, Nmesh=None, BoxSize=None, second=None,
                     axes=(0, 1), dk=None, kmin=0.):
 
-        FFTPowerBase.__init__(self, first, second, Nmesh, BoxSize)
+        FFTBase.__init__(self, first, second, Nmesh, BoxSize)
 
         # only deal with 1d and 2d projections.
         assert len(axes) in (1, 2), "length of ``axes`` in ProjectedFFTPower should be 1 or 2"
@@ -726,3 +778,4 @@ def _cast_source(source, BoxSize, Nmesh):
                           "`Nmesh` as keyword of to_mesh()"))
 
     return source
+

--- a/nbodykit/algorithms/fftpower.py
+++ b/nbodykit/algorithms/fftpower.py
@@ -29,7 +29,7 @@ class FFTPowerBase(object):
         the size of the linearly spaced ``k`` bins
     """
 
-    def __init__(self, first, second, Nmesh, BoxSize, kmin, dk):
+    def __init__(self, first, second, Nmesh, BoxSize):
         from pmesh.pm import ParticleMesh
 
         first = _cast_source(first, Nmesh=Nmesh, BoxSize=BoxSize)
@@ -56,11 +56,6 @@ class FFTPowerBase(object):
         self.attrs['Nmesh'] = first.attrs['Nmesh'].copy()
         self.attrs['BoxSize'] = first.attrs['BoxSize'].copy()
 
-        if dk is None:
-            dk = 2 * numpy.pi / self.attrs['BoxSize'].min()
-
-        self.attrs['dk'] = dk
-        self.attrs['kmin'] = kmin
         self.attrs.update(zip(['Lx', 'Ly', 'Lz'], self.attrs['BoxSize']))
         self.attrs.update({'volume':self.attrs['BoxSize'].prod()})
 
@@ -163,13 +158,19 @@ class FFTPower(FFTPowerBase):
         if not numpy.allclose(numpy.einsum('i,i', los, los), 1.0, rtol=1e-5):
             raise ValueError("line-of-sight ``los`` must be a unit vector")
 
-        FFTPowerBase.__init__(self, first, second, Nmesh, BoxSize, kmin, dk)
+        FFTPowerBase.__init__(self, first, second, Nmesh, BoxSize)
 
         # save meta-data
         self.attrs['mode'] = mode
         self.attrs['los'] = los
         self.attrs['Nmu'] = Nmu
         self.attrs['poles'] = poles
+
+        if dk is None:
+            dk = 2 * numpy.pi / self.attrs['BoxSize'].min()
+
+        self.attrs['dk'] = dk
+        self.attrs['kmin'] = kmin
 
         self.run()
 
@@ -395,10 +396,16 @@ class ProjectedFFTPower(FFTPowerBase):
     def __init__(self, first, Nmesh=None, BoxSize=None, second=None,
                     axes=(0, 1), dk=None, kmin=0.):
 
-        FFTPowerBase.__init__(self, first, second, Nmesh, BoxSize, kmin, dk)
+        FFTPowerBase.__init__(self, first, second, Nmesh, BoxSize)
 
         # only deal with 1d and 2d projections.
         assert len(axes) in (1, 2), "length of ``axes`` in ProjectedFFTPower should be 1 or 2"
+
+        if dk is None:
+            dk = 2 * numpy.pi / self.attrs['BoxSize'].min()
+
+        self.attrs['dk'] = dk
+        self.attrs['kmin'] = kmin
 
         self.attrs['axes'] = axes
         self.run()

--- a/nbodykit/algorithms/tests/test_fftcorr.py
+++ b/nbodykit/algorithms/tests/test_fftcorr.py
@@ -1,0 +1,91 @@
+from runtests.mpi import MPITest
+from nbodykit.lab import *
+from nbodykit import setup_logging
+from numpy.testing import assert_array_equal, assert_allclose
+import pytest
+
+# debug logging
+setup_logging("debug")
+
+@MPITest([1])
+def test_fftcorr_poles(comm):
+
+    CurrentMPIComm.set(comm)
+    source = UniformCatalog(nbar=3e-3, BoxSize=512., seed=42)
+
+    r = FFTCorr(source, mode='2d', BoxSize=1024, Nmesh=32, poles=[0,2,4])
+    pkmu = r.corr['corr'].real
+    mono = r.poles['corr_0'].real
+
+    modes_1d = r.corr['modes'].sum(axis=-1)
+    mono_from_pkmu = numpy.nansum(pkmu*r.corr['modes'], axis=-1) / modes_1d
+
+    assert_array_equal(modes_1d, r.poles['modes'])
+    assert_allclose(mono_from_pkmu, mono)
+
+
+@MPITest([1])
+def test_fftcorr_padding(comm):
+
+    CurrentMPIComm.set(comm)
+    source = UniformCatalog(nbar=3e-3, BoxSize=512., seed=42)
+
+    r = FFTCorr(source, mode='1d', BoxSize=1024, Nmesh=32)
+    assert r.attrs['N1'] != 0
+    assert r.attrs['N2'] != 0
+
+@MPITest([1])
+def test_fftcorr_padding(comm):
+
+    CurrentMPIComm.set(comm)
+    source = UniformCatalog(nbar=3e-3, BoxSize=512., seed=42)
+
+    r = FFTCorr(source, mode='1d', BoxSize=1024, Nmesh=32)
+    assert r.attrs['N1'] != 0
+    assert r.attrs['N2'] != 0
+
+@MPITest([1])
+def test_fftcorr_save(comm):
+
+    CurrentMPIComm.set(comm)
+    source = UniformCatalog(nbar=3e-3, BoxSize=512., seed=42)
+
+    r = FFTCorr(source, mode='2d', Nmesh=32)
+    r.save('fftcorr-test.json')
+
+    r2 = FFTCorr.load('fftcorr-test.json')
+
+    assert_array_equal(r.corr['r'], r2.corr['r'])
+    assert_array_equal(r.corr['corr'], r2.corr['corr'])
+    assert_array_equal(r.corr['mu'], r2.corr['mu'])
+    assert_array_equal(r.corr['modes'], r2.corr['modes'])
+
+
+@MPITest([1])
+def test_fftcorr_mismatch_boxsize(comm):
+
+    cosmo = cosmology.Planck15
+    CurrentMPIComm.set(comm)
+
+    # input sources
+    source1 = UniformCatalog(nbar=3e-3, BoxSize=512., seed=42)
+    Plin = cosmology.LinearPower(cosmo, 0.55, transfer='NoWiggleEisensteinHu')
+    source2 = LinearMesh(Plin, BoxSize=1024, Nmesh=32, seed=33)
+
+    r = FFTCorr(source1, second=source2, mode='1d', BoxSize=1024, Nmesh=32)
+
+@MPITest([1])
+def test_fftcorr_mismatch_boxsize_fail(comm):
+
+    cosmo = cosmology.Planck15
+    CurrentMPIComm.set(comm)
+
+    # input sources
+    mesh1 = UniformCatalog(nbar=3e-3, BoxSize=512., seed=42).to_mesh(Nmesh=32)
+    Plin = cosmology.LinearPower(cosmo, 0.55, transfer='NoWiggleEisensteinHu')
+    mesh2 = LinearMesh(Plin, BoxSize=1024, Nmesh=32, seed=33)
+
+    # raises an exception b/c meshes have different box sizes
+    with pytest.raises(ValueError):
+        r = FFTCorr(mesh1, second=mesh2, mode='1d', BoxSize=1024, Nmesh=32)
+

--- a/nbodykit/mockmaker.py
+++ b/nbodykit/mockmaker.py
@@ -6,7 +6,9 @@ from pmesh.pm import RealField, ComplexField
 from nbodykit.meshtools import SlabIterator
 from nbodykit.utils import GatherArray, ScatterArray
 
-def gaussian_complex_fields(pm, linear_power, seed, remove_variance=False, compute_displacement=False):
+def gaussian_complex_fields(pm, linear_power, seed,
+            unitary_amplitude=False, inverted_phase=False,
+            compute_displacement=False):
     r"""
     Make a Gaussian realization of a overdensity field, :math:`\delta(x)`.
 
@@ -59,9 +61,10 @@ def gaussian_complex_fields(pm, linear_power, seed, remove_variance=False, compu
     compute_displacement : bool, optional
         if ``True``, also return the linear Zel'dovich displacement field;
         default is ``False``
-    remove_variance : bool, optional
-        if ``True``, remove the variance in the amplitude of the guassian,
-        such that the power spectrum of the realization is exactly the input.
+    unitary_amplitude : bool, optional
+        if ``True``, the seed gaussian has unitary_amplitude.
+    inverted_phase: bool, optional
+        if ``True``, the phase of the seed gaussian is inverted
 
     Returns
     -------
@@ -76,7 +79,9 @@ def gaussian_complex_fields(pm, linear_power, seed, remove_variance=False, compu
     # use pmesh to generate random complex white noise field (done in parallel)
     # variance of complex field is unity
     # multiply by P(k)**0.5 to get desired variance
-    delta_k = pm.generate_whitenoise(seed, mode='complex', unitary=remove_variance)
+    delta_k = pm.generate_whitenoise(seed, mode='complex', unitary=unitary_amplitude)
+
+    if inverted_phase: delta_k[...] *= -1
 
     # initialize the displacement fields for (x,y,z)
     if compute_displacement:
@@ -124,7 +129,9 @@ def gaussian_complex_fields(pm, linear_power, seed, remove_variance=False, compu
     return delta_k, disp_k
 
 
-def gaussian_real_fields(pm, linear_power, seed, compute_displacement=False):
+def gaussian_real_fields(pm, linear_power, seed,
+                unitary_amplitude=False,
+                inverted_phase=False, compute_displacement=False):
     r"""
     Make a Gaussian realization of a overdensity field in
     real-space :math:`\delta(x)`.
@@ -150,6 +157,10 @@ def gaussian_real_fields(pm, linear_power, seed, compute_displacement=False):
     compute_displacement : bool, optional
         if ``True``, also return the linear Zel'dovich displacement field;
         default is ``False``
+    unitary_amplitude : bool, optional
+        if ``True``, the seed gaussian has unitary_amplitude.
+    inverted_phase: bool, optional
+        if ``True``, the phase of the seed gaussian is inverted
 
     Returns
     -------
@@ -159,7 +170,10 @@ def gaussian_real_fields(pm, linear_power, seed, compute_displacement=False):
         if requested, the Gaussian displacement field
     """
     # make fourier fields
-    delta_k, disp_k = gaussian_complex_fields(pm, linear_power, seed, compute_displacement=compute_displacement)
+    delta_k, disp_k = gaussian_complex_fields(pm, linear_power, seed,
+                            inverted_phase=inverted_phase,
+                            unitary_amplitude=unitary_amplitude,
+                            compute_displacement=compute_displacement)
 
     # FFT the density to real-space
     delta = delta_k.c2r()

--- a/nbodykit/source/catalog/lognormal.py
+++ b/nbodykit/source/catalog/lognormal.py
@@ -48,7 +48,9 @@ class LogNormalCatalog(CatalogSource):
 
     @CurrentMPIComm.enable
     def __init__(self, Plin, nbar, BoxSize, Nmesh, bias=2., seed=None,
-                    cosmo=None, redshift=None, comm=None, use_cache=False):
+                    cosmo=None, redshift=None,
+                    unitary_amplitude=False, inverted_phase=False,
+                    comm=None, use_cache=False):
 
         self.comm = comm
         self.Plin = Plin
@@ -74,6 +76,8 @@ class LogNormalCatalog(CatalogSource):
         self.attrs['nbar']  = nbar
         self.attrs['redshift'] = redshift
         self.attrs['bias'] = bias
+        self.attrs['unitary_amplitude'] = unitary_amplitude
+        self.attrs['inverted_phase'] = inverted_phase
 
         # set the seed randomly if it is None
         if seed is None:
@@ -132,7 +136,10 @@ class LogNormalCatalog(CatalogSource):
         f = self.cosmo.scale_independent_growth_rate(self.attrs['redshift'])
 
         # compute the linear overdensity and displacement fields
-        delta, disp = mockmaker.gaussian_real_fields(pm, self.Plin, self.attrs['seed'], compute_displacement=True)
+        delta, disp = mockmaker.gaussian_real_fields(pm, self.Plin, self.attrs['seed'], 
+                    unitary_amplitude=self.attrs['unitary_amplitude'],
+                    inverted_phase=self.attrs['inverted_phase'],
+                    compute_displacement=True)
 
         # poisson sample to points
         # this returns position and velocity offsets

--- a/nbodykit/source/mesh/linear.py
+++ b/nbodykit/source/mesh/linear.py
@@ -20,7 +20,14 @@ class LinearMesh(MeshSource):
     seed : int, optional
         the global random seed, used to set the seeds across all ranks
     remove_variance : bool, optional
+        :deprecated:`use unitary_amplitude instead`
         ``True`` to remove variance from the complex field by fixing the
+        amplitude to :math:`P(k)` and only the phase is random.
+    unitary_amplitude: bool, optional
+        ``True`` to remove variance from the complex field by fixing the
+        amplitude to :math:`P(k)` and only the phase is random.
+    inverted_phase: bool, optional
+        ``True`` to invert phase of the complex field by fixing the
         amplitude to :math:`P(k)` and only the phase is random.
     comm : MPI communicator
         the MPI communicator
@@ -29,7 +36,11 @@ class LinearMesh(MeshSource):
         return "LinearMesh(seed=%(seed)d)" % self.attrs
 
     @CurrentMPIComm.enable
-    def __init__(self, Plin, BoxSize, Nmesh, seed=None, remove_variance=False, comm=None):
+    def __init__(self, Plin, BoxSize, Nmesh, seed=None,
+            unitary_amplitude=False,
+            inverted_phase=False,
+            remove_variance=None,
+            comm=None):
 
         self.Plin = Plin
 
@@ -44,7 +55,11 @@ class LinearMesh(MeshSource):
                 seed = numpy.random.randint(0, 4294967295)
             seed = self.comm.bcast(seed)
         self.attrs['seed'] = seed
-        self.attrs['remove_variance'] = remove_variance
+        if remove_variance is not None:
+            unitary_amplitude = remove_variance
+
+        self.attrs['unitary_amplitude'] = unitary_amplitude
+        self.attrs['inverted_phase'] = inverted_phase
 
         MeshSource.__init__(self, BoxSize=BoxSize, Nmesh=Nmesh, dtype='f4', comm=comm)
 
@@ -64,7 +79,10 @@ class LinearMesh(MeshSource):
             field in Fourier space
         """
         # generate linear density field with desired seed
-        complex, _ = mockmaker.gaussian_complex_fields(self.pm, self.Plin, self.attrs['seed'], remove_variance=self.attrs['remove_variance'], compute_displacement=False)
+        complex, _ = mockmaker.gaussian_complex_fields(self.pm, self.Plin, self.attrs['seed'], 
+                    unitary_amplitude=self.attrs['unitary_amplitude'],
+                    inverted_phase=self.attrs['inverted_phase'],
+                    compute_displacement=False)
         # set normalization to 1 + \delta.
         def filter(k, v):
             mask = numpy.bitwise_and.reduce([ki == 0 for ki in k])


### PR DESCRIPTION
This PR adds FFT based Correlation Function; closes #434 

Main issue is that the interface between PairCount and FFTPower is different. Not sure which to follow

- FFTPower uses .power, ['power']
- PairCount uses .result, ['xi'].

I also added flags to LinearMesh and LogNormalCatalog to generate unitary / inverted phase realizations.