### PR TITLE
Add default columns and do not save them to disk

### DIFF
--- a/nbodykit/base/catalog.py
+++ b/nbodykit/base/catalog.py
@@ -1,10 +1,12 @@
 from nbodykit.transform import ConstantArray
 from nbodykit import _global_options, CurrentMPIComm
 
-from six import string_types
+from six import string_types, add_metaclass
 import numpy
 import logging
 import warnings
+import abc
+import inspect
 import dask.array as da
 
 class ColumnAccessor(da.Array):
@@ -65,70 +67,72 @@ class ColumnAccessor(da.Array):
             r = r + " last: %s" % str(self[-1].compute())
         return r
 
-def column(name=None):
+def column(name=None, default=False):
     """
-    Decorator that defines a function as a column in a CatalogSource
+    Decorator that defines the decorated function as a column in a
+    CatalogSource.
+
+    This can be used as a decorator with or without arguments. If no ``name``
+    is specified, the function name is used.
+
+    Parameters
+    ----------
+    name : str, optional
+        the name of the column; if not provided, the name of the function
+        being decorated is used
+    default : bool, optional
+        whether the column is a default column
     """
-    def decorator(getter):
-        getter.column_name = name
+    def decorator(getter, name=name):
+        getter.column_name = getter.__name__ if name is None else name
+        getter.default_column = default
         return getter
 
+    # handle the case when decorator was called without arguments
+    # in that case "name" is actually the function we are decorating
     if hasattr(name, '__call__'):
-        # a single callable is provided
         getter = name
-        name = getter.__name__
-        return decorator(getter)
+        return decorator(getter, name=getter.__name__)
     else:
         return decorator
 
-
-def find_columns(cls):
+class ColumnFinder(abc.ABCMeta):
     """
-    Find all hard-coded column names associated with the input class
+    A meta-class that will register all columns of a class that have
+    been marked with the :func:`column` decorator.
 
-    Returns
-    -------
-    hardcolumns : set
-        a set of the names of all hard-coded columns for the
-        input class ``cls``
+    This adds the following attributes to the class definition:
+
+    1. ``_defaults`` : default columns, specified by passing ``default=True`` to
+    the :func:`column` decorator.
+    2. ``_hardcolumns`` : non-default, hard-coded columns
+
+    .. note::
+        This is a subclass of :class:`abc.ABCMeta` so subclasses can
+        define abstract properties, if they need to.
     """
-    hardcolumns = []
+    def __init__(cls, clsname, bases, attrs):
 
-    # search through the class dict for columns
-    for key, value in cls.__dict__.items():
-         if hasattr(value, 'column_name'):
-            hardcolumns.append(value.column_name)
+        # attach the registry attributes
+        cls._defaults = set()
+        cls._hardcolumns = set()
 
-    # recursively search the base classes, too
-    for base in cls.__bases__:
-        hardcolumns += find_columns(base)
+        # for each class and base classes, track ParameterProperty
+        # and CachedProperty attributes
+        classes = inspect.getmro(cls)
+        for c in reversed(classes):
 
-    return list(sorted(set(hardcolumns)))
+            # loop over each attribute
+            for name in c.__dict__:
+                value = c.__dict__[name]
+                # track cached property
+                if getattr(value, 'column_name', None):
+                    if value.default_column:
+                        cls._defaults.add(value.column_name)
+                    else:
+                        cls._hardcolumns.add(value.column_name)
 
-
-def find_column(cls, name):
-    """
-    Find a specific column ``name`` of an input class, or raise
-    an exception if it does not exist
-
-    Returns
-    -------
-    column : callable
-        the callable that returns the column data
-    """
-    # first search through class
-    for key, value in cls.__dict__.items():
-        if not hasattr(value, 'column_name'): continue
-        if value.column_name == name: return value
-
-    for base in cls.__bases__:
-        try: return find_column(base, name)
-        except: pass
-
-    args = (name, str(cls))
-    raise AttributeError("unable to find column '%s' for '%s'" % args)
-
-
+@add_metaclass(ColumnFinder)
 class CatalogSourceBase(object):
     """
     An abstract base class that implements most of the functionality in
@@ -140,6 +144,11 @@ class CatalogSourceBase(object):
     .. note::
         See the docstring for :class:`CatalogSource`. Most often, users should
         implement custom sources as subclasses of :class:`CatalogSource`.
+
+    The names of hard-coded columns, i.e., those defined through member
+    functions of the class, are stored in the :attr:`_defaults` and
+    :attr:`_hardcolumns` attributes. These attributes are computed by the
+    :class:`ColumnFinder` meta-class.
 
     Parameters
     ----------
@@ -190,7 +199,7 @@ class CatalogSourceBase(object):
         # initialize a cache
         obj.use_cache = kwargs.get('use_cache', False)
 
-        # user-provided overrides for columns
+        # user-provided overrides and defaults for columns
         obj._overrides = {}
 
         # stores memory owner
@@ -220,7 +229,8 @@ class CatalogSourceBase(object):
         """
         if isinstance(other, CatalogSourceBase):
             d = other.__dict__.copy()
-            nocopy = ['base', '_overrides', 'comm', '_cache', '_use_cache', '_size', '_csize']
+            nocopy = ['base', '_overrides', '_hardcolumns', '_defaults', 'comm',
+                      '_cache', '_use_cache', '_size', '_csize']
             for key in d:
                 if key not in nocopy:
                     self.__dict__[key] = d[key]
@@ -342,12 +352,11 @@ class CatalogSourceBase(object):
             r = memowner._overrides[sel]
         elif sel in memowner.hardcolumns:
             r = memowner.get_hardcolumn(sel)
+        elif sel in memowner._defaults:
+            r = getattr(memowner, sel)()
         else:
             raise KeyError("column `%s` is not defined in this source; " %sel + \
                             "try adding column via `source[column] = data`")
-
-        # evaluate callables if we need to
-        if callable(r): r = r()
 
         # return a ColumnAccessor for pretty prints
         return ColumnAccessor(memowner, r)
@@ -427,6 +436,18 @@ class CatalogSourceBase(object):
             return self._attrs
 
     @property
+    def defaults(self):
+        """
+        A list of the hard-coded, default columns in the CatalogSource.
+
+        These objects must be member functions of the class, marked
+        by ``@column(default=True)``
+        """
+        if self.base is not None: return self.base.defaults
+
+        return sorted(self._defaults)
+
+    @property
     def hardcolumns(self):
         """
         A list of the hard-coded columns in the CatalogSource.
@@ -441,11 +462,9 @@ class CatalogSourceBase(object):
         """
         if self.base is not None: return self.base.hardcolumns
 
-        try:
-            self._hardcolumns
-        except AttributeError:
-            self._hardcolumns = find_columns(self.__class__)
-        return self._hardcolumns
+        # return the non-default, hard-coded columns, as determined by
+        # ColumnFinder metaclass
+        return sorted(self._hardcolumns)
 
     @property
     def columns(self):
@@ -459,9 +478,8 @@ class CatalogSourceBase(object):
         """
         if self.base is not None: return self.base.columns
 
-        hcolumns  = list(self.hardcolumns)
         overrides = list(self._overrides)
-        return sorted(set(hcolumns + overrides))
+        return sorted(set(self.hardcolumns + overrides + self.defaults))
 
     def copy(self):
         """
@@ -514,7 +532,10 @@ class CatalogSourceBase(object):
         """
         if self.base is not None: return self.base.get_hardcolumn(col)
 
-        return find_column(self.__class__, col)(self)
+        if col in self._hardcolumns:
+            return getattr(self, col)()
+        else:
+            raise ValueError("no such hard-coded column %s" %col)
 
     def compute(self, *args, **kwargs):
         """
@@ -1008,7 +1029,7 @@ class CatalogSource(CatalogSourceBase):
             toret.attrs.update(self.attrs)
             return toret
 
-    @column
+    @column(default=True)
     def Selection(self):
         """
         A boolean column that selects a subset slice of the CatalogSource.
@@ -1017,7 +1038,7 @@ class CatalogSource(CatalogSourceBase):
         """
         return ConstantArray(True, self.size, chunks=_global_options['dask_chunk_size'])
 
-    @column
+    @column(default=True)
     def Weight(self):
         """
         The column giving the weight to use for each particle on the mesh.
@@ -1043,7 +1064,7 @@ class CatalogSource(CatalogSourceBase):
         return da.arange(offset, offset + self.size, dtype='i8',
                chunks=_global_options['dask_chunk_size'])
 
-    @column
+    @column(default=True)
     def Value(self):
         """
         When interpolating a CatalogSource on to a mesh, the value of this

--- a/nbodykit/base/tests/test_catalog.py
+++ b/nbodykit/base/tests/test_catalog.py
@@ -2,10 +2,24 @@ from runtests.mpi import MPITest
 from nbodykit.lab import *
 from nbodykit import setup_logging, set_options
 
+import os
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 
 setup_logging()
+
+@MPITest([1])
+def test_default_columns(comm):
+    CurrentMPIComm.set(comm)
+
+    cat = UniformCatalog(nbar=100, BoxSize=1.0)
+
+    # weight column is default
+    assert cat['Weight'].is_default
+
+    # override the default value --> no longer default
+    cat['Weight'] = 10.
+    assert not cat['Weight'].is_default
 
 
 @MPITest([1, 4])
@@ -31,10 +45,14 @@ def test_save(comm):
     source.attrs['empty'] = None
 
     # save to a BigFile
-    source.save(tmpfile, ['Position', 'Velocity'])
+    source.save(tmpfile, source.columns)
+
+    # assert that no default columns were saved
+    datasets = os.listdir(tmpfile)
+    assert not any(col in datasets for col in ['Value', 'Selection', 'Weight'])
 
     # load as a BigFileCatalog
-    source2 = BigFileCatalog(tmpfile, header='Header', attrs={"Nmesh":32})
+    source2 = BigFileCatalog(tmpfile, attrs={"Nmesh":32})
 
     # check sources
     for k in source.attrs:

--- a/nbodykit/base/tests/test_catalog.py
+++ b/nbodykit/base/tests/test_catalog.py
@@ -94,7 +94,7 @@ def test_bad_column(comm):
         data = source.read(['BAD_COLUMN'])
 
     # read a missing column
-    with pytest.raises(AttributeError):
+    with pytest.raises(ValueError):
         data = source.get_hardcolumn('BAD_COLUMN')
 
 @MPITest([4])

--- a/nbodykit/io/base.py
+++ b/nbodykit/io/base.py
@@ -1,7 +1,7 @@
 from six import string_types
 import numpy
 import logging
-from abc import abstractmethod, abstractproperty
+from abc import abstractmethod
 from nbodykit import _global_options
 
 class FileType(object):

--- a/nbodykit/source/catalog/hod.py
+++ b/nbodykit/source/catalog/hod.py
@@ -29,7 +29,6 @@ def find_object_dtypes(data):
             raise TypeError("column '%s' is of type 'O'; must convert to integer or string" %col)
     return data
 
-@add_metaclass(abc.ABCMeta)
 class HODBase(ArrayCatalog):
     """
     A base class to be used for HOD population of a halo catalog.


### PR DESCRIPTION
This fixes #431.

* introduces "default" columns --> these are columns that are defined via class member functions
* add a metaclass to CatalogSource that picks up default columns and hard coded columns that are part of the class
* add ``is_default`` attribute to ColumnAccessor, letting users test if a column is default; I thought this was better than a ``defaults`` list, which would change as columns are overriden 
* filter out and do not save defaults in CatalogSource.save()