### PR TITLE
fix bigfile attrs when there is no header block.

### DIFF
--- a/nbodykit/io/bigfile.py
+++ b/nbodykit/io/bigfile.py
@@ -54,7 +54,7 @@ class BigFile(FileType):
         with bigfile.BigFile(filename=path) as ff:
             columns = ff[self.dataset].blocks
             if header is Automatic:
-                for header in ['Header', 'header', './']:
+                for header in ['Header', 'header', '.']:
                     if header in columns: break
 
             if exclude is None:


### PR DESCRIPTION
A typo causes ./ used and a File object is returned instead of
a BigBlock object.

```
~/anaconda3/install/lib/python3.6/site-packages/nbodykit/source/catalog/file.py in __init__(self, filetype, args, kwargs, comm)
     43         # bcast the FileStack
     44         if self.comm.rank == 0:
---> 45             self._source = FileStack(filetype, *args, **kwargs)
     46         else:
     47             self._source = None

~/anaconda3/install/lib/python3.6/site-packages/nbodykit/io/stack.py in __init__(self, filetype, path, *args, **kwargs)
     50         else:
     51             raise ValueError("'path' should be a string or a list of strings")
---> 52         self.files = [filetype(fn, *args, **kwargs) for fn in filenames]
     53         self.sizes = numpy.array([len(f) for f in self.files], dtype='i8')
     54

~/anaconda3/install/lib/python3.6/site-packages/nbodykit/io/stack.py in <listcomp>(.0)
     50         else:
     51             raise ValueError("'path' should be a string or a list of strings")
---> 52         self.files = [filetype(fn, *args, **kwargs) for fn in filenames]
     53         self.sizes = numpy.array([len(f) for f in self.files], dtype='i8')
     54

~/anaconda3/install/lib/python3.6/site-packages/nbodykit/io/bigfile.py in __init__(self, path, exclude, header, dataset)
     70
     71             header = ff[header]
---> 72             attrs = header.attrs
     73
     74             # copy over the attrs

AttributeError: 'File' object has no attribute 'attrs'
```