### PR TITLE
FIX: MeshSource.apply broken if MeshSource.action is overriden.

### DIFF
--- a/nbodykit/base/mesh.py
+++ b/nbodykit/base/mesh.py
@@ -52,6 +52,8 @@ class MeshSource(object):
         self.attrs['BoxSize'] = self.pm.BoxSize.copy()
         self.attrs['Nmesh'] = self.pm.Nmesh.copy()
 
+        # modify the underlying method
+        # actions may have been overriden!
         self._actions = []
         self.base = None
 
@@ -71,7 +73,7 @@ class MeshSource(object):
             self.pm = other.pm
             self.attrs.update(other.attrs)
             self._actions = []
-            self.actions.extend(other.actions)
+            self._actions.extend(other.actions)
 
         return self
 
@@ -155,7 +157,9 @@ class MeshSource(object):
             assert kind in ['wavenumber', 'circular', 'index']
 
         view = self.view()
-        view.actions.append((mode, func, kind))
+        # modify the underlying method
+        # actions may have been overriden!
+        view._actions.append((mode, func, kind))
         return view
 
     def __len__(self):

--- a/nbodykit/base/tests/test_catalogmesh.py
+++ b/nbodykit/base/tests/test_catalogmesh.py
@@ -2,7 +2,7 @@ from runtests.mpi import MPITest
 from nbodykit.lab import *
 from nbodykit import set_options
 from nbodykit import setup_logging
-from numpy.testing import assert_array_equal, assert_allclose
+from numpy.testing import assert_array_equal, assert_allclose, assert_raises
 import pytest
 
 # debug logging
@@ -230,9 +230,10 @@ def test_view(comm):
     # adding columns to the view changes original source
     view['TEST2'] = 5.0
     assert 'TEST2' in source
+class CodeReached(BaseException): pass
 
 @MPITest([1, 4])
-def test_apply(comm):
+def test_apply_nocompensation(comm):
     CurrentMPIComm.set(comm)
 
     # the CatalogSource
@@ -242,10 +243,15 @@ def test_apply(comm):
     source.attrs['TEST'] = 10.0
 
     # the mesh
-    mesh = source.to_mesh(position='Position2', Nmesh=32)
-    mesh = mesh.apply(lambda k, v: v)
+    mesh = source.to_mesh(position='Position2', Nmesh=32, compensated=False)
 
-    real = mesh.paint()
+    def raisefunc(k, v):
+        raise CodeReached
+
+    mesh = mesh.apply(raisefunc)
+
+    assert_raises(CodeReached, mesh.paint)
+
     # view
     view = mesh.view()
     assert view.base is mesh
@@ -254,3 +260,27 @@ def test_apply(comm):
     # check meta-data
     for k in mesh.attrs:
         assert k in view.attrs
+
+    def raise_filter(k, v):
+        raise
+
+@MPITest([1])
+def test_apply_compensated(comm):
+    CurrentMPIComm.set(comm)
+
+    # the CatalogSource
+    source = UniformCatalog(nbar=0.2e-3, BoxSize=1024., seed=42)
+    source['TEST'] = 10.
+    source['Position2'] = source['Position']
+    source.attrs['TEST'] = 10.0
+
+    # the mesh
+    mesh = source.to_mesh(position='Position2', Nmesh=32, compensated=True)
+
+    def raisefunc(k, v):
+        raise CodeReached
+
+    mesh = mesh.apply(raisefunc)
+
+    assert_raises(CodeReached, mesh.paint)
+


### PR DESCRIPTION
if action is overriden action.append will modify a transient instance.