### PR TITLE
bigfile shall look for header starting from root.

### DIFF
--- a/nbodykit/io/bigfile.py
+++ b/nbodykit/io/bigfile.py
@@ -85,11 +85,13 @@ class BigFile(FileType):
         """ Find header from the file block by default. """
         if header is Automatic:
             for header in ['Header', 'header', '.']:
-                if header in ff.columns: break
+                if header in ff.blocks: break
 
-        if not header in ff.columns:
-            raise KeyError("header block `%s` is not defined in the bigfile. Candidates can be `%s`"
-                    % (header, str(ff.columns))
+        # shall not make the assertion here because header can be nested deep.
+        # then not shown in ff.blocks. try catch may work better.
+        #if not header in ff.blocks:
+        #    raise KeyError("header block `%s` is not defined in the bigfile. Candidates can be `%s`"
+        #            % (header, str(ff.blocks))
 
         return header
 

--- a/nbodykit/io/bigfile.py
+++ b/nbodykit/io/bigfile.py
@@ -54,7 +54,7 @@ class BigFile(FileType):
         # the file path
         with bigfile.BigFile(filename=path) as ff:
             columns = ff[self.dataset].blocks
-            header = self.find_header(header, ff)
+            header = self._find_header(header, ff)
 
             if exclude is None:
                 # by default exclude header only.


### PR DESCRIPTION
As specified in the documentation. The rational is that
this way one can always easily specify a special header block in not
in the dataset. If it were relative to the dataset then there is
no way to load the header if it is outside.

This fix solves a few occasions where scripts mysteriously stopped
working when loading catalog.