### PR TITLE
FIX: PairCount crashes if two data sets are of different dtypes.

### DIFF
--- a/docs/source/results/algorithms/index.rst
+++ b/docs/source/results/algorithms/index.rst
@@ -28,6 +28,7 @@ Correlation Function Algorithms
   :maxdepth: 1
 
   fftcorr
+  paircount
   two-pt-cf
   three-pt-cf
 

--- a/docs/source/results/algorithms/paircount.rst
+++ b/docs/source/results/algorithms/paircount.rst
@@ -1,0 +1,10 @@
+.. currentmodule:: nbodykit.algorithms.pair_counters
+
+
+Pair Counts for Data in a Simulation Box (:class:`~SimulationBoxPairCount`)
+=========================================================================================
+
+Pair Counts for Survey Data (:class:`~SurveyDataPairCount`)
+============================================================================
+This includes angular clustering as well.
+

--- a/docs/source/results/algorithms/projected-fftpower.rst
+++ b/docs/source/results/algorithms/projected-fftpower.rst
@@ -2,5 +2,5 @@ currentmodule:: nbodykit.algorithms.fftpower
 
 .. _projected-fftpower:
 
-Power Spectrum of a Projected Field (:class:`ProjectedFFTPower`)
+Power Spectrum of a Projected Field (:class:`~.ProjectedFFTPower`)
 ================================================================

--- a/docs/source/results/algorithms/three-pt-cf.rst
+++ b/docs/source/results/algorithms/three-pt-cf.rst
@@ -1,2 +1,7 @@
-Multipoles of the Isotropic, 3-pt Correlation Function (:class:`~nbodykit.algorithms.threeptcf.Multipoles3PCF`)
-===============================================================================================================
+.. currentmodule:: nbodykit.algorithms.threeptcf
+
+3-pt Correlation Function for Data in a Simulation Box (:class:`~SimulationBox3PCF`)
+===================================================================================
+
+3-pt Correlation Function for Survey Data (:class:`~SurveyData3PCF`)
+====================================================================

--- a/docs/source/results/algorithms/two-pt-cf.rst
+++ b/docs/source/results/algorithms/two-pt-cf.rst
@@ -1,12 +1,8 @@
-.. currentmodule:: nbodykit.algorithms
+.. currentmodule:: nbodykit.algorithms.paircount_tpcf.tpcf
 
+Correlation Function for Data in a Simulation Box (:class:`~SimulationBox2PCF`)
+===============================================================================
 
-Pair Counts for Data in a Simulation Box (:class:`~sim_paircount.SimulationBoxPairCount`)
-=========================================================================================
-
-Pair Counts for Survey Data (:class:`~survey_paircount.SurveyDataPairCount`)
-============================================================================
-
-
-Angular Pair Counts for Survey Data (:class:`~survey_paircount.AngularPairCount`)
-=================================================================================
+Correlation Function for Survey Data (:class:`~SurveyData2PCF`)
+===============================================================
+This includes angular clustering as well.

--- a/nbodykit/algorithms/pair_counters/corrfunc/mocks.py
+++ b/nbodykit/algorithms/pair_counters/corrfunc/mocks.py
@@ -42,10 +42,10 @@ class CorrfuncMocksCallable(MPICorrfuncCallable):
         kws.update(config)
 
         def callback(kws, chunk):
-            kws['RA1'] = pos1[chunk][:,0]
-            kws['DEC1'] = pos1[chunk][:,1]
-            if threedims: kws['CZ1'] = pos1[chunk][:,2]
-            kws['weights1'] = w1[chunk].astype(pos1.dtype)
+            kws['RA1'] = pos1[chunk][:,0].astype(pos2.dtype)
+            kws['DEC1'] = pos1[chunk][:,1].astype(pos2.dtype)
+            if threedims: kws['CZ1'] = pos1[chunk][:,2].astype(pos2.dtype)
+            kws['weights1'] = w1[chunk].astype(pos2.dtype)
 
         # compute the result
         sizes = self.comm.allgather(len(pos1))

--- a/nbodykit/algorithms/pair_counters/corrfunc/theory.py
+++ b/nbodykit/algorithms/pair_counters/corrfunc/theory.py
@@ -52,10 +52,10 @@ class CorrfuncTheoryCallable(MPICorrfuncCallable):
         kws.update(config)
 
         def callback(kws, chunk):
-            kws['X1'] = pos1[chunk][:,0]
-            kws['Y1'] = pos1[chunk][:,1]
-            kws['Z1'] = pos1[chunk][:,2] # LOS defined with respect to this axis
-            kws['weights1'] = w1[chunk].astype(pos1.dtype)
+            kws['X1'] = pos1[chunk][:,0].astype(pos2.dtype)
+            kws['Y1'] = pos1[chunk][:,1].astype(pos2.dtype)
+            kws['Z1'] = pos1[chunk][:,2].astype(pos2.dtype) # LOS defined with respect to this axis
+            kws['weights1'] = w1[chunk].astype(pos2.dtype)
 
         # compute the result
         sizes = self.comm.allgather(len(pos1))

--- a/nbodykit/algorithms/pair_counters/domain.py
+++ b/nbodykit/algorithms/pair_counters/domain.py
@@ -253,6 +253,9 @@ def decompose_survey_data(first, second, attrs, logger, smoothing, domain_factor
     # balance the load
     domain.loadbalance(domain.load(cpos1))
 
+    if comm.rank == 0:
+        logger.info("Load balance done")
+
     # if we want to return cartesian, redefine pos
     if return_cartesian:
         pos1 = cpos1

--- a/nbodykit/source/catalog/uniform.py
+++ b/nbodykit/source/catalog/uniform.py
@@ -200,7 +200,7 @@ class UniformCatalog(RandomCatalog):
         return "UniformCatalog(size=%d, seed=%s)" % args
 
     @CurrentMPIComm.enable
-    def __init__(self, nbar, BoxSize, seed=None, comm=None):
+    def __init__(self, nbar, BoxSize, seed=None, dtype='f8', comm=None):
 
         self.comm    = comm
 
@@ -214,8 +214,8 @@ class UniformCatalog(RandomCatalog):
             raise ValueError("no uniform particles generated, try increasing `nbar` parameter")
         RandomCatalog.__init__(self, N, seed=seed, comm=comm)
 
-        self._pos = self.rng.uniform(size=(self._size, 3)) * self.attrs['BoxSize']
-        self._vel = self.rng.uniform(size=(self._size, 3)) * self.attrs['BoxSize'] * 0.01
+        self._pos = (self.rng.uniform(size=(self._size, 3)) * self.attrs['BoxSize']).astype(dtype)
+        self._vel = (self.rng.uniform(size=(self._size, 3)) * self.attrs['BoxSize'] * 0.01).astype(dtype)
 
     @column
     def Position(self):


### PR DESCRIPTION
This PR fixes the crash if data and random are of different dtypes in SurveyDataPairCount and SimulationBoxPairCount. Both use corrfunc which doesn't handle this case. 

Therefore we cast the input to the type of pos2 instead of throwing a mysterious CorrFunc error.
