### PR TITLE
ENH: Allow new type in BinnedStatistics.copy().

### DIFF
--- a/nbodykit/binned_statistic.py
+++ b/nbodykit/binned_statistic.py
@@ -527,12 +527,17 @@ class BinnedStatistic(object):
         return cls(dims, edges, data, **meta)
 
 
-    def copy(self):
+    def copy(self, cls=None):
         """
-        Returns a copy of the BinnedStatistic
+        Returns a copy of the BinnedStatistic, optionally change the type
+        to cls. cls must be a subclass of BinnedStatistic.
         """
         attrs = self.__copy_attrs__()
-        cls = self.__class__
+        if cls is None:
+            cls = self.__class__
+        if not issubclass(cls, BinnedStatistic):
+            raise TypeError("The cls argument must be a subclass of BinnedStatistic")
+
         return cls.__construct_direct__(self.data.copy(), self.mask.copy(), **attrs)
 
     def rename_variable(self, old_name, new_name):


### PR DESCRIPTION
Also asserts subclass type is preserved during sel(). This paves
the road for the plan described in

https://github.com/bccp/nbodykit/pull/477#discussion_r186141206