### PR TITLE
Avoid using pm.x; it will be removed in pmesh 0.1.43.

### DIFF
--- a/nbodykit/mockmaker.py
+++ b/nbodykit/mockmaker.py
@@ -296,7 +296,7 @@ def poisson_sample_to_points(delta, displacement, pm, nbar, bias=1., seed=None, 
     for i in range(delta.ndim):
 
         # particle positions initially on the coordinate grid
-        pos_mesh[i] = numpy.squeeze(delta.pm.x[i])[nonzero_cells[i]]
+        pos_mesh[i] = numpy.squeeze(delta.x[i])[nonzero_cells[i]]
 
         # displacements for each particle
         disp_mesh[i] = displacement[i][nonzero_cells]


### PR DESCRIPTION
We shall tag a release after this, such that we can tag an incompatible release of pmesh; which the faster lognormal branch will eventually depend on.