### PR TITLE
Improving scaling of LogNormalCatalog (v2)

### DIFF
--- a/nbodykit/algorithms/pair_counters/tests/test_1d.py
+++ b/nbodykit/algorithms/pair_counters/tests/test_1d.py
@@ -267,7 +267,7 @@ def test_survey_cross(comm):
 
     # random particles
     first = generate_survey_data(seed=42, dtype='f4')
-    first['Weight'] = first.rng.uniform()
+    first['Weight'] = first.rng.uniform(dtype='f4')
     # mismatched dtype shouldn't fail
     second = generate_survey_data(seed=84, dtype='f8')
     second['Weight'] = second.rng.uniform()
@@ -285,9 +285,11 @@ def test_survey_cross(comm):
 
     # verify with kdcount
     npairs, ravg, wsum = reference_paircount(pos1, w1, redges, None, pos2=pos2, w2=w2)
-    assert_allclose(ravg, r.pairs['r'], rtol=1e-6)
     assert_allclose(npairs, r.pairs['npairs'])
     assert_allclose(wsum, r.pairs['wnpairs'])
+    # the error can be larger due to single precision positions in one of
+    # the dataset
+    assert_allclose(ravg, r.pairs['r'], rtol=1e-5)
 
 @MPITest([1])
 def test_survey_missing_columns(comm):

--- a/nbodykit/algorithms/pair_counters/tests/test_1d.py
+++ b/nbodykit/algorithms/pair_counters/tests/test_1d.py
@@ -19,9 +19,9 @@ def generate_survey_data(seed, dtype='f8'):
     cosmo = cosmology.Planck15
     s = RandomCatalog(1000, seed=seed)
 
-    s['Redshift'] = s.rng.normal(loc=0.5, scale=0.1, size=s.size).astype(dtype)
-    s['RA'] = s.rng.uniform(low=0, high=360, size=s.size).astype(dtype)
-    s['DEC'] = s.rng.uniform(low=-60, high=60., size=s.size).astype(dtype)
+    s['Redshift'] = s.rng.normal(loc=0.5, scale=0.1).astype(dtype)
+    s['RA'] = s.rng.uniform(low=0, high=360).astype(dtype)
+    s['DEC'] = s.rng.uniform(low=-60, high=60.).astype(dtype)
     s['Position'] = transform.SkyToCartesian(s['RA'], s['DEC'], s['Redshift'], cosmo=cosmo).astype(dtype)
 
     return s
@@ -48,7 +48,7 @@ def test_sim_periodic_auto(comm):
     source = generate_sim_data(seed=42)
 
     # add some weights b/w 0 and 1
-    source['Weight'] = source.rng.uniform(size=len(source))
+    source['Weight'] = source.rng.uniform()
 
     # make the bin edges
     redges = numpy.linspace(10, 150, 10)
@@ -203,7 +203,7 @@ def test_survey_auto(comm):
     source = generate_survey_data(seed=42)
 
     # add some weights b/w 0 and 1
-    source['Weight'] = source.rng.uniform(size=len(source))
+    source['Weight'] = source.rng.uniform()
 
     # make the bin edges
     redges = numpy.linspace(10, 150, 10)
@@ -237,7 +237,7 @@ def test_survey_auto_endianess(comm):
     source['DEC'] = source['DEC'].astype('>f8')
     source['Redshift'] = source['Redshift'].astype('>f8')
     # add some weights b/w 0 and 1
-    source['Weight'] = source.rng.uniform(size=len(source)).astype('>f8')
+    source['Weight'] = source.rng.uniform().astype('>f8')
     source['Position'] = source['Position'].astype('>f8')
 
     # make the bin edges
@@ -267,10 +267,10 @@ def test_survey_cross(comm):
 
     # random particles
     first = generate_survey_data(seed=42, dtype='f4')
-    first['Weight'] = first.rng.uniform(size=first.size)
+    first['Weight'] = first.rng.uniform()
     # mismatched dtype shouldn't fail
     second = generate_survey_data(seed=84, dtype='f8')
-    second['Weight'] = second.rng.uniform(size=second.size)
+    second['Weight'] = second.rng.uniform()
 
     # make the bin edges
     redges = numpy.linspace(10, 150, 10)

--- a/nbodykit/algorithms/pair_counters/tests/test_2d.py
+++ b/nbodykit/algorithms/pair_counters/tests/test_2d.py
@@ -19,9 +19,9 @@ def generate_survey_data(seed):
     s = RandomCatalog(1000, seed=seed)
 
     # ra, dec, z
-    s['Redshift'] = s.rng.normal(loc=0.5, scale=0.1, size=s.size)
-    s['RA'] = s.rng.uniform(low=110, high=260, size=s.size)
-    s['DEC'] = s.rng.uniform(low=-3.6, high=60., size=s.size)
+    s['Redshift'] = s.rng.normal(loc=0.5, scale=0.1)
+    s['RA'] = s.rng.uniform(low=110, high=260)
+    s['DEC'] = s.rng.uniform(low=-3.6, high=60.)
 
     # position
     s['Position'] = transform.SkyToCartesian(s['RA'], s['DEC'], s['Redshift'], cosmo=cosmo)
@@ -89,7 +89,7 @@ def test_sim_diff_los(comm):
     source = generate_sim_data(seed=42)
 
     # add some weights b/w 0 and 1
-    source['Weight'] = source.rng.uniform(size=len(source))
+    source['Weight'] = source.rng.uniform()
 
     # make the bin edges
     redges = numpy.linspace(10, 150, 10)
@@ -163,7 +163,7 @@ def test_survey_auto(comm):
 
     # random particles
     source = generate_survey_data(seed=42)
-    source['Weight'] = source.rng.uniform(size=source.size)
+    source['Weight'] = source.rng.uniform()
 
     # make the bin edges
     redges = numpy.linspace(10, 1000., 10)
@@ -189,9 +189,9 @@ def test_survey_cross(comm):
 
     # random particles
     first = generate_survey_data(seed=42)
-    first['Weight'] = first.rng.uniform(size=first.size)
+    first['Weight'] = first.rng.uniform()
     second = generate_survey_data(seed=84)
-    second['Weight'] = second.rng.uniform(size=second.size)
+    second['Weight'] = second.rng.uniform()
 
     # make the bin edges
     redges = numpy.linspace(10, 150, 10)

--- a/nbodykit/algorithms/pair_counters/tests/test_2d.py
+++ b/nbodykit/algorithms/pair_counters/tests/test_2d.py
@@ -63,7 +63,7 @@ def test_sim_periodic_auto(comm):
     source = generate_sim_data(seed=42)
 
     # add some weights b/w 0 and 1
-    source['Weight'] = source.rng.uniform(size=len(source))
+    source['Weight'] = source.rng.uniform()
 
     # make the bin edges
     redges = numpy.linspace(10, 150, 10)

--- a/nbodykit/algorithms/pair_counters/tests/test_angular.py
+++ b/nbodykit/algorithms/pair_counters/tests/test_angular.py
@@ -16,8 +16,8 @@ def gather_data(source, name):
 
 def generate_survey_data(seed):
     s = RandomCatalog(1000, seed=seed)
-    s['RA'] = s.rng.uniform(low=50, high=260, size=s.size)
-    s['DEC'] = s.rng.uniform(low=-10.6, high=60., size=s.size)
+    s['RA'] = s.rng.uniform(low=50, high=260)
+    s['DEC'] = s.rng.uniform(low=-10.6, high=60.)
     return s
 
 def generate_sim_data(seed):
@@ -48,7 +48,7 @@ def test_survey_auto(comm):
     source = generate_survey_data(seed=42)
 
     # add some weights b/w 0 and 1
-    source['Weight'] = source.rng.uniform(size=len(source))
+    source['Weight'] = source.rng.uniform()
 
     # make the bin edges
     edges = numpy.linspace(0.001, 1.0, 10)
@@ -75,9 +75,9 @@ def test_survey_cross(comm):
 
     # random particles with weights
     first = generate_survey_data(seed=42)
-    first['Weight'] = first.rng.uniform(size=first.size)
+    first['Weight'] = first.rng.uniform()
     second = generate_survey_data(seed=84)
-    second['Weight'] = second.rng.uniform(size=second.size)
+    second['Weight'] = second.rng.uniform()
 
     # make the bin edges
     edges = numpy.linspace(0.001, 1.0, 10)
@@ -113,7 +113,7 @@ def test_sim_auto(comm):
     source = generate_sim_data(seed=42)
 
     # add some weights b/w 0 and 1
-    source['Weight'] = source.rng.uniform(size=len(source))
+    source['Weight'] = source.rng.uniform()
 
     # make the bin edges
     edges = numpy.linspace(0.001, 1.0, 10)
@@ -140,9 +140,9 @@ def test_sim_cross(comm):
 
     # random particles with weights
     first = generate_sim_data(seed=42)
-    first['Weight'] = first.rng.uniform(size=first.size)
+    first['Weight'] = first.rng.uniform()
     second = generate_sim_data(seed=84)
-    second['Weight'] = second.rng.uniform(size=second.size)
+    second['Weight'] = second.rng.uniform()
 
     # make the bin edges
     edges = numpy.linspace(0.001, 1.0, 10)

--- a/nbodykit/algorithms/pair_counters/tests/test_projected.py
+++ b/nbodykit/algorithms/pair_counters/tests/test_projected.py
@@ -101,7 +101,7 @@ def reference_survey_paircount(pos1, w1, rp_bins, pimax, pos2=None, w2=None, los
     wnpairs.flat += numpy.bincount(multi_index, weights=w1[i]*w2[j], minlength=wnpairs.size)
     wnpairs = wnpairs[1:-1,1:-1]
 
-    return npairs, rpavg/npairs, wnpairs
+    return npairs, numpy.nan_to_num(rpavg/npairs), numpy.nan_to_num(wnpairs)
 
 
 @MPITest([1, 3])

--- a/nbodykit/algorithms/pair_counters/tests/test_projected.py
+++ b/nbodykit/algorithms/pair_counters/tests/test_projected.py
@@ -18,9 +18,9 @@ def generate_survey_data(seed):
     s = RandomCatalog(1000, seed=seed)
 
     # ra, dec, z
-    s['Redshift'] = s.rng.normal(loc=0.5, scale=0.1, size=s.size)
-    s['RA'] = s.rng.uniform(low=110, high=260, size=s.size)
-    s['DEC'] = s.rng.uniform(low=-3.6, high=60., size=s.size)
+    s['Redshift'] = s.rng.normal(loc=0.5, scale=0.1)
+    s['RA'] = s.rng.uniform(low=110, high=260)
+    s['DEC'] = s.rng.uniform(low=-3.6, high=60.)
 
     # position
     s['Position'] = transform.SkyToCartesian(s['RA'], s['DEC'], s['Redshift'], cosmo=cosmo)
@@ -112,7 +112,7 @@ def test_sim_periodic_auto(comm):
     source = generate_sim_data(seed=42)
 
     # add some weights b/w 0 and 1
-    source['Weight'] = source.rng.uniform(size=len(source))
+    source['Weight'] = source.rng.uniform()
 
     # make the bin edges
     redges = numpy.linspace(10, 150, 10)
@@ -135,7 +135,7 @@ def test_sim_diff_los(comm):
     source = generate_sim_data(seed=42)
 
     # add some weights b/w 0 and 1
-    source['Weight'] = source.rng.uniform(size=len(source))
+    source['Weight'] = source.rng.uniform()
 
     # make the bin edges
     redges = numpy.linspace(10, 150, 10)
@@ -199,7 +199,7 @@ def test_survey_auto(comm):
 
     # random particles
     source = generate_survey_data(seed=42)
-    source['Weight'] = source.rng.uniform(size=source.size)
+    source['Weight'] = source.rng.uniform()
 
     # make the bin edges
     redges = numpy.linspace(10, 1000., 10)
@@ -224,9 +224,9 @@ def test_survey_cross(comm):
 
     # random particles
     first = generate_survey_data(seed=42)
-    first['Weight'] = first.rng.uniform(size=first.size)
+    first['Weight'] = first.rng.uniform()
     second = generate_survey_data(seed=84)
-    second['Weight'] = second.rng.uniform(size=second.size)
+    second['Weight'] = second.rng.uniform()
 
     # make the bin edges
     redges = numpy.linspace(10, 150, 10)

--- a/nbodykit/algorithms/tests/test_cgm.py
+++ b/nbodykit/algorithms/tests/test_cgm.py
@@ -46,7 +46,7 @@ def test_periodic_cgm(comm):
     source = UniformCatalog(3e-4, BoxSize=256, seed=42)
 
     # add mass
-    logmass = source.rng.uniform(12, 15, size=source.size)
+    logmass = source.rng.uniform(12, 15)
     source['halo_mvir'] = 10**(logmass)
 
     # add fake galaxy types
@@ -88,7 +88,7 @@ def test_nonperiodic_cgm(comm):
     source = UniformCatalog(3e-4, BoxSize=256, seed=42)
 
     # add mass
-    logmass = source.rng.uniform(12, 15, size=source.size)
+    logmass = source.rng.uniform(12, 15)
     source['halo_mvir'] = 10**(logmass)
 
     # add fake galaxy types

--- a/nbodykit/algorithms/tests/test_conv_power.py
+++ b/nbodykit/algorithms/tests/test_conv_power.py
@@ -20,9 +20,9 @@ def make_sources(cosmo):
     for s in [data, randoms]:
 
         # ra, dec, z
-        s['z']   = s.rng.normal(loc=0.5, scale=0.1, size=s.size)
-        s['ra']  = s.rng.uniform(low=110, high=260, size=s.size)
-        s['dec'] = s.rng.uniform(low=-3.6, high=60., size=s.size)
+        s['z']   = s.rng.normal(loc=0.5, scale=0.1)
+        s['ra']  = s.rng.uniform(low=110, high=260)
+        s['dec'] = s.rng.uniform(low=-3.6, high=60.)
 
         # position
         s['Position'] = transform.SkyToCartesian(s['ra'], s['dec'], s['z'], cosmo=cosmo)

--- a/nbodykit/algorithms/tests/test_fftrecon.py
+++ b/nbodykit/algorithms/tests/test_fftrecon.py
@@ -29,5 +29,5 @@ def test_fftrecon(comm):
     r2 = FFTPower(data, mode='1d')
 
     # reconstruction shouldn't have matter much on large scale.
-    assert_allclose(r1.power['power'][:5], r2.power['power'][:5], rtol=0.04)
+    assert_allclose(r1.power['power'][:5], r2.power['power'][:5], rtol=0.05)
 

--- a/nbodykit/algorithms/tests/test_zhist.py
+++ b/nbodykit/algorithms/tests/test_zhist.py
@@ -17,7 +17,7 @@ def test_save(comm):
     
     # create the source
     source = RandomCatalog(N, seed=42)
-    source['z'] = source.rng.normal(loc=0.5, scale=0.1, size=source.size)
+    source['z'] = source.rng.normal(loc=0.5, scale=0.1)
     
     # compute the histogram
     r = RedshiftHistogram(source, FSKY, cosmo, redshift='z')
@@ -44,7 +44,7 @@ def test_unweighted(comm):
     
     # create the source
     source = RandomCatalog(N, seed=42)
-    source['z'] = source.rng.normal(loc=0.5, scale=0.1, size=source.size)
+    source['z'] = source.rng.normal(loc=0.5, scale=0.1)
     
     # compute the histogram
     r = RedshiftHistogram(source, FSKY, cosmo, redshift='z')
@@ -63,8 +63,8 @@ def test_weighted(comm):
     
     # create the source
     source = RandomCatalog(N, seed=42)
-    source['z'] = source.rng.normal(loc=0.5, scale=0.1, size=source.size)
-    source['weight'] = source.rng.uniform(0, high=1., size=source.size)
+    source['z'] = source.rng.normal(loc=0.5, scale=0.1)
+    source['weight'] = source.rng.uniform(0, high=1.)
     
     # compute the histogram
     r = RedshiftHistogram(source, FSKY, cosmo, redshift='z', weight='weight')

--- a/nbodykit/base/tests/test_catalog.py
+++ b/nbodykit/base/tests/test_catalog.py
@@ -126,10 +126,9 @@ def test_empty_slice(comm):
     assert source is source2
 
     # non-empty selection on root only
-    if comm.rank == 0:
-        sel = source.rng.choice([True, False], size=source.size)
-    else:
-        sel = numpy.ones(source.size, dtype=bool)
+    sel = source.rng.choice([True, False])
+    if comm.rank != 0:
+        sel[...] = True
 
     # this should trigger a full slice
     source2 = source[sel]

--- a/nbodykit/base/tests/test_catalogmesh.py
+++ b/nbodykit/base/tests/test_catalogmesh.py
@@ -39,7 +39,7 @@ def test_sort_ascending(comm):
 
     # the mesh to sort
     d = UniformCatalog(100, 1.0)
-    d['mass'] = 10**(d.rng.uniform(low=12, high=15, size=d.size))
+    d['mass'] = 10**(d.rng.uniform(low=12, high=15))
     mesh = d.to_mesh(Nmesh=32)
 
     # invalid sort key

--- a/nbodykit/mockmaker.py
+++ b/nbodykit/mockmaker.py
@@ -78,6 +78,9 @@ def gaussian_complex_fields(pm, linear_power, seed,
     if not isinstance(seed, numbers.Integral):
         raise ValueError("the seed used to generate the linear field must be an integer")
 
+    if logger and pm.comm.rank == 0:
+        logger.info("Generating whitenoise")
+
     # use pmesh to generate random complex white noise field (done in parallel)
     # variance of complex field is unity
     # multiply by P(k)**0.5 to get desired variance

--- a/nbodykit/mockmaker.py
+++ b/nbodykit/mockmaker.py
@@ -84,7 +84,7 @@ def gaussian_complex_fields(pm, linear_power, seed,
     # use pmesh to generate random complex white noise field (done in parallel)
     # variance of complex field is unity
     # multiply by P(k)**0.5 to get desired variance
-    delta_k = pm.generate_whitenoise(seed, mode='complex', unitary=unitary_amplitude)
+    delta_k = pm.generate_whitenoise(seed, type='untransposedcomplex', unitary=unitary_amplitude)
 
     if logger and pm.comm.rank == 0:
         logger.info("Write noise generated")
@@ -93,7 +93,7 @@ def gaussian_complex_fields(pm, linear_power, seed,
 
     # initialize the displacement fields for (x,y,z)
     if compute_displacement:
-        disp_k = [ComplexField(pm) for i in range(delta_k.ndim)]
+        disp_k = [pm.create(type='untransposedcomplex') for i in range(delta_k.ndim)]
         for i in range(delta_k.ndim): disp_k[i][:] = 1j
     else:
         disp_k = None

--- a/nbodykit/mockmaker.py
+++ b/nbodykit/mockmaker.py
@@ -219,7 +219,8 @@ def lognormal_transform(density, bias=1.):
     """
     toret = density.copy()
     toret[:] = numpy.exp(bias * density.value)
-    toret[:] /= numpy.mean(toret)
+    toret[:] /= toret.cmean(dtype='f8')
+
     return toret
 
 

--- a/nbodykit/mockmaker.py
+++ b/nbodykit/mockmaker.py
@@ -5,6 +5,7 @@ from mpi4py import MPI
 from pmesh.pm import RealField, ComplexField
 from nbodykit.meshtools import SlabIterator
 from nbodykit.utils import GatherArray, ScatterArray
+from nbodykit.mpirng import MPIRandomState
 
 def gaussian_complex_fields(pm, linear_power, seed,
             unitary_amplitude=False, inverted_phase=False,

--- a/nbodykit/mockmaker.py
+++ b/nbodykit/mockmaker.py
@@ -295,7 +295,6 @@ def poisson_sample_to_points(delta, displacement, pm, nbar, bias=1., seed=None):
 
     # fight round off errors, if any
     N_per_cell = numpy.int64(N_per_cell + 0.5)
-    N_per_cell[...] = 1
 
     pos = pos_mesh.repeat(N_per_cell, axis=0)
     disp = disp_mesh.repeat(N_per_cell, axis=0)

--- a/nbodykit/mpirng.py
+++ b/nbodykit/mpirng.py
@@ -73,6 +73,14 @@ class MPIRandomState:
             return rng.poisson(lam=lam, size=size)
         return self._call_rngmethod(sampler, (lam,), itemshape, dtype)
 
+    def choice(self, choices, itemshape=(), replace=True, p=None):
+        """ Produce `self.size` choices, each of shape itemshape. This is a collective MPI call. """
+        dtype = numpy.array(choices).dtype
+        def sampler(rng, args, size):
+            return rng.choice(choices, size=size, replace=replace, p=p)
+
+        return self._call_rngmethod(sampler, (), itemshape, dtype)
+
     def normal(self, loc=0, scale=1, itemshape=(), dtype='f8'):
         """ Produce `self.size` normals, each of shape itemshape. This is a collective MPI call. """
         def sampler(rng, args, size):

--- a/nbodykit/mpirng.py
+++ b/nbodykit/mpirng.py
@@ -3,6 +3,16 @@ import numpy
 from nbodykit.utils import FrontPadArray
 
 class MPIRandomState:
+    """ A Random number generator that is invariant against number of ranks,
+        when the total size of random number requested is kept the same.
+
+        The algorithm here assumes the random number generator from numpy
+        produces uncorrelated results when the seeds are sampled from a single
+        RNG.
+
+        The sampler methods are collective calls.
+
+    """
     def __init__(self, comm, seed, size, chunksize=10000):
         self.comm = comm
         self.seed = seed
@@ -32,12 +42,14 @@ class MPIRandomState:
         return padded[0], padded[1:]
 
     def poisson(self, lam, itemshape=(), dtype='f8'):
+        """ Produce `self.size` poissons. This is a collective MPI call. """
         def func(rng, args, size):
             lam, = args
             return rng.poisson(lam=lam, size=size)
         return self._call_rngmethod(func, (lam,), itemshape, dtype)
 
     def uniform(self, low=0., high=1.0, itemshape=(), dtype='f8'):
+        """ Produce `self.size` uniforms. This is a collective MPI call. """
         def func(rng, args, size):
             low, high = args
             return rng.uniform(low=low, high=high,size=size)

--- a/nbodykit/mpirng.py
+++ b/nbodykit/mpirng.py
@@ -13,7 +13,7 @@ class MPIRandomState:
         The sampler methods are collective calls.
 
     """
-    def __init__(self, comm, seed, size, chunksize=10000):
+    def __init__(self, comm, seed, size, chunksize=100000):
         self.comm = comm
         self.seed = seed
         self.chunksize = chunksize

--- a/nbodykit/mpirng.py
+++ b/nbodykit/mpirng.py
@@ -78,7 +78,7 @@ class MPIRandomState:
         def sampler(rng, args, size):
             loc, scale = args
             return rng.normal(loc=loc, scale=scale, size=size)
-        return self._call_rngmethod(sampler, (lam,), itemshape, dtype)
+        return self._call_rngmethod(sampler, (loc, scale), itemshape, dtype)
 
     def uniform(self, low=0., high=1.0, itemshape=(), dtype='f8'):
         """ Produce `self.size` uniforms, each of shape itemshape. This is a collective MPI call. """

--- a/nbodykit/mpirng.py
+++ b/nbodykit/mpirng.py
@@ -1,0 +1,124 @@
+from numpy.random import RandomState
+import numpy
+import functools
+import contextlib
+
+N_PER_SEED = 100000
+
+def _mpi_enabled_rng(func):
+    """
+    A decorator that handles generating random numbers in parallel
+    in a manner that is independent of the number of ranks
+
+    Designed to be used with :class:`MPIRandomState`
+    """
+    @functools.wraps(func)
+    def func_wrapper(*args, **kwargs):
+
+        self = func.__self__
+        size = kwargs.get('size', None)
+        if size is not None and isinstance(size, int):
+            size = (size,)
+
+        # do nothing if size not provided or wrong
+        if size is None or size[0] != self.size:
+            return func(*args, **kwargs)
+
+        # size matches the "size" attribute
+        else:
+            toret = []
+
+            # loop through chunks that this rank is responsible for
+            for chunk, (start, stop) in zip(self._chunks, self._slices):
+                with self.seeded_context(self._seeds[chunk]):
+
+                    kwargs['size'] = (N_PER_SEED,) + size[1:]
+                    if chunk == self.N // N_PER_SEED:
+                        kwargs['size'] = (self.N % N_PER_SEED,) + size[1:]
+                    toret.append(func(*args, **kwargs)[start:stop])
+            return numpy.concatenate(toret, axis=0)
+
+    func_wrapper.mpi_enabled = True
+    return func_wrapper
+
+class MPIRandomState(RandomState):
+    """
+    A wrapper around :class:`numpy.random.RandomState` that can return
+    random numbers in parallel, independent of the number of ranks.
+
+    Parameters
+    ----------
+    comm : MPI communicator
+        the MPI communicator
+    seed : int
+        the global seed that seeds all other random seeds
+    localsize : int
+        the local size of the random numbers to generate; we return chunks of
+        the total on each CPU, based on the CPU's rank
+    """
+    def __init__(self, comm, seed, localsize):
+
+        RandomState.__init__(self, seed=seed)
+
+        N = comm.allreduce(numpy.int64(localsize))
+
+        # the number of seeds to generate N particles
+        n_seeds = N // N_PER_SEED
+        if N % N_PER_SEED: n_seeds += 1
+
+        self.comm        = comm
+        self.global_seed = seed
+        self.N           = N
+
+        start = numpy.sum(comm.allgather(localsize)[:comm.rank], dtype='intp')
+        stop  = start + localsize
+        self.size  = stop - start
+
+        # generate the full set of seeds from the global seed
+        rng = numpy.random.RandomState(seed=seed)
+        self._seeds = rng.randint(0, high=0xffffffff, size=n_seeds)
+
+        # sizes of each chunk
+        sizes = [N_PER_SEED]*(N//N_PER_SEED)
+        if N % N_PER_SEED: sizes.append(N % N_PER_SEED)
+
+        # the local chunks this rank is responsible for
+        cumsizes = numpy.insert(numpy.cumsum(sizes), 0, 0)
+        chunk_range = numpy.searchsorted(cumsizes[1:], [start, stop])
+        self._chunks = list(range(chunk_range[0], chunk_range[1]+1))
+
+        # and the slices for each local chunk
+        self._slices = []
+        for chunk in self._chunks:
+            start_size = cumsizes[chunk]
+            sl = (max(start-start_size, 0), min(stop-start_size, sizes[chunk]))
+            self._slices.append(sl)
+
+    def __dir__(self):
+        """
+        Explicitly set the attributes as those of the RandomState class too
+        """
+        d1 = set(RandomState().__dir__())
+        d2 = set(RandomState.__dir__(self))
+        return list(d1|d2)
+
+    def __getattribute__(self, name):
+        """
+        Decorate callable functions of RandomState such that they return
+        chunks of the total `N` random numbers generated
+        """
+        attr = RandomState.__getattribute__(self, name)
+        if callable(attr) and not getattr(attr, 'mpi_enabled', False):
+            attr = _mpi_enabled_rng(attr)
+        return attr
+
+    @contextlib.contextmanager
+    def seeded_context(self, seed):
+        """
+        A context manager to set and then restore the random seed
+        """
+        startstate = self.get_state()
+        self.seed(seed)
+        yield
+        self.set_state(startstate)
+

--- a/nbodykit/source/catalog/lognormal.py
+++ b/nbodykit/source/catalog/lognormal.py
@@ -130,7 +130,7 @@ class LogNormalCatalog(CatalogSource):
         # the particle mesh for gridding purposes
         _Nmesh = numpy.empty(3, dtype='i8')
         _Nmesh[:] = Nmesh
-        pm = ParticleMesh(BoxSize=BoxSize, Nmesh=_Nmesh, dtype='f4', comm=self.comm, transposed=False)
+        pm = ParticleMesh(BoxSize=BoxSize, Nmesh=_Nmesh, dtype='f4', comm=self.comm)
 
         # growth rate to do RSD in the Zel'dovich approx
         f = self.cosmo.scale_independent_growth_rate(self.attrs['redshift'])

--- a/nbodykit/source/catalog/lognormal.py
+++ b/nbodykit/source/catalog/lognormal.py
@@ -140,7 +140,7 @@ class LogNormalCatalog(CatalogSource):
 
         # poisson sample to points
         # this returns position and velocity offsets
-        kws = {'bias':self.attrs['bias'], 'seed':self.attrs['seed'], 'comm':self.comm}
+        kws = {'bias':self.attrs['bias'], 'seed':self.attrs['seed']}
         pos, disp = mockmaker.poisson_sample_to_points(delta, disp, pm, self.attrs['nbar'], **kws)
 
         # move particles from initial position based on the Zeldovich displacement

--- a/nbodykit/source/catalog/lognormal.py
+++ b/nbodykit/source/catalog/lognormal.py
@@ -130,7 +130,7 @@ class LogNormalCatalog(CatalogSource):
         # the particle mesh for gridding purposes
         _Nmesh = numpy.empty(3, dtype='i8')
         _Nmesh[:] = Nmesh
-        pm = ParticleMesh(BoxSize=BoxSize, Nmesh=_Nmesh, dtype='f4', comm=self.comm)
+        pm = ParticleMesh(BoxSize=BoxSize, Nmesh=_Nmesh, dtype='f4', comm=self.comm, transposed=False)
 
         # growth rate to do RSD in the Zel'dovich approx
         f = self.cosmo.scale_independent_growth_rate(self.attrs['redshift'])

--- a/nbodykit/source/catalog/lognormal.py
+++ b/nbodykit/source/catalog/lognormal.py
@@ -142,14 +142,15 @@ class LogNormalCatalog(CatalogSource):
         delta, disp = mockmaker.gaussian_real_fields(pm, self.Plin, self.attrs['seed'],
                     unitary_amplitude=self.attrs['unitary_amplitude'],
                     inverted_phase=self.attrs['inverted_phase'],
-                    compute_displacement=True)
+                    compute_displacement=True,
+                    logger=self.logger)
 
         if self.comm.rank == 0:
             self.logger.info("gaussian field is generated")
 
         # poisson sample to points
         # this returns position and velocity offsets
-        kws = {'bias':self.attrs['bias'], 'seed':self.attrs['seed']}
+        kws = {'bias':self.attrs['bias'], 'seed':self.attrs['seed'], 'logger' : self.logger}
         pos, disp = mockmaker.poisson_sample_to_points(delta, disp, pm, self.attrs['nbar'], **kws)
 
         if self.comm.rank == 0:

--- a/nbodykit/source/catalog/tests/test_lognormal.py
+++ b/nbodykit/source/catalog/tests/test_lognormal.py
@@ -1,8 +1,11 @@
 from runtests.mpi import MPITest
 from nbodykit.lab import *
 from nbodykit import setup_logging
+from nbodykit.utils import GatherArray
 
 from numpy.testing import assert_allclose
+from numpy.testing import assert_array_equal
+from mpi4py import MPI
 
 setup_logging("debug")
 
@@ -31,6 +34,22 @@ def test_lognormal_dense(comm):
 
     real = mesh.paint(mode='real')
     assert_allclose(real.cmean(), 1.0, rtol=1e-5)
+
+@MPITest([4])
+def test_lognormal_invariance(comm):
+    cosmo = cosmology.Planck15
+    CurrentMPIComm.set(comm)
+
+    Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
+    source = LogNormalCatalog(Plin=Plin, nbar=0.5e-2, BoxSize=1024., Nmesh=32, seed=42)
+    source1 = LogNormalCatalog(Plin=Plin, nbar=0.5e-2, BoxSize=1024., Nmesh=32, seed=42, comm=MPI.COMM_SELF)
+
+    assert source.csize == source1.size
+
+    allpos = GatherArray(source['Position'].compute(), root=Ellipsis, comm=comm)
+    assert_allclose(allpos, source1['Position'])
+    alldis = GatherArray(source['Velocity'].compute(), root=Ellipsis, comm=comm)
+    assert_allclose(alldis, source1['Velocity'])
 
 @MPITest([1])
 def test_lognormal_velocity(comm):

--- a/nbodykit/source/catalog/tests/test_lognormal.py
+++ b/nbodykit/source/catalog/tests/test_lognormal.py
@@ -41,8 +41,8 @@ def test_lognormal_invariance(comm):
     CurrentMPIComm.set(comm)
 
     Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
-    source = LogNormalCatalog(Plin=Plin, nbar=0.5e-2, BoxSize=1024., Nmesh=32, seed=42)
-    source1 = LogNormalCatalog(Plin=Plin, nbar=0.5e-2, BoxSize=1024., Nmesh=32, seed=42, comm=MPI.COMM_SELF)
+    source = LogNormalCatalog(Plin=Plin, nbar=0.5e-2, BoxSize=128., Nmesh=32, seed=42)
+    source1 = LogNormalCatalog(Plin=Plin, nbar=0.5e-2, BoxSize=128., Nmesh=32, seed=42, comm=MPI.COMM_SELF)
 
     assert source.csize == source1.size
 
@@ -57,7 +57,7 @@ def test_lognormal_velocity(comm):
     CurrentMPIComm.set(comm)
 
     Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
-    source = LogNormalCatalog(Plin=Plin, nbar=0.5e-2, BoxSize=1024., Nmesh=32, seed=42)
+    source = LogNormalCatalog(Plin=Plin, nbar=0.5e-2, BoxSize=128., Nmesh=32, seed=42)
 
     source['Value'] = source['Velocity'][:, 0]**2
     mesh = source.to_mesh(compensated=False)

--- a/nbodykit/source/catalog/tests/test_uniform.py
+++ b/nbodykit/source/catalog/tests/test_uniform.py
@@ -1,0 +1,20 @@
+from nbodykit.source.catalog.uniform import UniformCatalog
+from runtests.mpi import MPITest
+from nbodykit.lab import CurrentMPIComm
+from nbodykit.utils import GatherArray
+from numpy.testing import assert_array_equal
+from mpi4py import MPI
+
+@MPITest([4])
+def test_uniform_invariant(comm):
+    cat = UniformCatalog(nbar=2, BoxSize=100., seed=1234, dtype='f4', comm=comm)
+
+    cat1 = UniformCatalog(nbar=2, BoxSize=100., seed=1234, dtype='f4', comm=MPI.COMM_SELF)
+
+    allpos = GatherArray(cat['Position'].compute(), root=Ellipsis, comm=comm)
+
+    assert_array_equal(allpos, cat1['Position'])
+
+    allvel = GatherArray(cat['Velocity'].compute(), root=Ellipsis, comm=comm)
+
+    assert_array_equal(allvel, cat1['Velocity'])

--- a/nbodykit/source/catalog/uniform.py
+++ b/nbodykit/source/catalog/uniform.py
@@ -45,7 +45,7 @@ class RandomCatalog(CatalogSource):
         end   = (comm.rank + 1) * csize // comm.size
         self._size =  end - start
 
-        self._rng = MPIRandomState(comm, seed, self._size)
+        self._rng = MPIRandomState(comm, seed=seed, size=self._size)
 
         # init the base class
         CatalogSource.__init__(self, comm=comm)
@@ -97,8 +97,8 @@ class UniformCatalog(RandomCatalog):
             raise ValueError("no uniform particles generated, try increasing `nbar` parameter")
         RandomCatalog.__init__(self, N, seed=seed, comm=comm)
 
-        self._pos = (self.rng.uniform(size=(self._size, 3)) * self.attrs['BoxSize']).astype(dtype)
-        self._vel = (self.rng.uniform(size=(self._size, 3)) * self.attrs['BoxSize'] * 0.01).astype(dtype)
+        self._pos = (self.rng.uniform(itemshape=(3,)) * self.attrs['BoxSize']).astype(dtype)
+        self._vel = (self.rng.uniform(itemshape=(3,)) * self.attrs['BoxSize'] * 0.01).astype(dtype)
 
     @column
     def Position(self):

--- a/nbodykit/source/catalog/uniform.py
+++ b/nbodykit/source/catalog/uniform.py
@@ -1,127 +1,7 @@
 from nbodykit.base.catalog import CatalogSource, column
 from nbodykit import CurrentMPIComm
-
-from numpy.random import RandomState
+from nbodykit.mpirng import MPIRandomState
 import numpy
-import functools
-import contextlib
-
-N_PER_SEED = 100000
-
-def _mpi_enabled_rng(func):
-    """
-    A decorator that handles generating random numbers in parallel
-    in a manner that is independent of the number of ranks
-
-    Designed to be used with :class:`MPIRandomState`
-    """
-    @functools.wraps(func)
-    def func_wrapper(*args, **kwargs):
-
-        self = func.__self__
-        size = kwargs.get('size', None)
-        if size is not None and isinstance(size, int):
-            size = (size,)
-
-        # do nothing if size not provided or wrong
-        if size is None or size[0] != self.size:
-            return func(*args, **kwargs)
-
-        # size matches the "size" attribute
-        else:
-            toret = []
-
-            # loop through chunks that this rank is responsible for
-            for chunk, (start, stop) in zip(self._chunks, self._slices):
-                with self.seeded_context(self._seeds[chunk]):
-
-                    kwargs['size'] = (N_PER_SEED,) + size[1:]
-                    if chunk == self.N // N_PER_SEED:
-                        kwargs['size'] = (self.N % N_PER_SEED,) + size[1:]
-                    toret.append(func(*args, **kwargs)[start:stop])
-            return numpy.concatenate(toret, axis=0)
-
-    func_wrapper.mpi_enabled = True
-    return func_wrapper
-
-class MPIRandomState(RandomState):
-    """
-    A wrapper around :class:`numpy.random.RandomState` that can return
-    random numbers in parallel, independent of the number of ranks.
-
-    Parameters
-    ----------
-    comm : MPI communicator
-        the MPI communicator
-    seed : int
-        the global seed that seeds all other random seeds
-    N : int
-        the total size of the random numbers to generate; we return chunks of
-        the total on each CPU, based on the CPU's rank
-    """
-    def __init__(self, comm, seed, N):
-
-        RandomState.__init__(self, seed=seed)
-
-        # the number of seeds to generate N particles
-        n_seeds = N // N_PER_SEED
-        if N % N_PER_SEED: n_seeds += 1
-
-        self.comm        = comm
-        self.global_seed = seed
-        self.N           = N
-
-        start = N * comm.rank // comm.size
-        stop  = N * (comm.rank  + 1) // comm.size
-        self.size  = stop - start
-
-        # generate the full set of seeds from the global seed
-        rng = numpy.random.RandomState(seed=seed)
-        self._seeds = rng.randint(0, high=0xffffffff, size=n_seeds)
-
-        # sizes of each chunk
-        sizes = [N_PER_SEED]*(N//N_PER_SEED)
-        if N % N_PER_SEED: sizes.append(N % N_PER_SEED)
-
-        # the local chunks this rank is responsible for
-        cumsizes = numpy.insert(numpy.cumsum(sizes), 0, 0)
-        chunk_range = numpy.searchsorted(cumsizes[1:], [start, stop])
-        self._chunks = list(range(chunk_range[0], chunk_range[1]+1))
-
-        # and the slices for each local chunk
-        self._slices = []
-        for chunk in self._chunks:
-            start_size = cumsizes[chunk]
-            sl = (max(start-start_size, 0), min(stop-start_size, sizes[chunk]))
-            self._slices.append(sl)
-
-    def __dir__(self):
-        """
-        Explicitly set the attributes as those of the RandomState class too
-        """
-        d1 = set(RandomState().__dir__())
-        d2 = set(RandomState.__dir__(self))
-        return list(d1|d2)
-
-    def __getattribute__(self, name):
-        """
-        Decorate callable functions of RandomState such that they return
-        chunks of the total `N` random numbers generated
-        """
-        attr = RandomState.__getattribute__(self, name)
-        if callable(attr) and not getattr(attr, 'mpi_enabled', False):
-            attr = _mpi_enabled_rng(attr)
-        return attr
-
-    @contextlib.contextmanager
-    def seeded_context(self, seed):
-        """
-        A context manager to set and then restore the random seed
-        """
-        startstate = self.get_state()
-        self.seed(seed)
-        yield
-        self.set_state(startstate)
 
 class RandomCatalog(CatalogSource):
     """
@@ -161,8 +41,11 @@ class RandomCatalog(CatalogSource):
         # generate the seeds from the global seed
         if csize == 0:
             raise ValueError("no random particles generated!")
-        self._rng = MPIRandomState(comm, seed, csize)
-        self._size =  self.rng.size
+        start = comm.rank * csize // comm.size
+        end   = (comm.rank + 1) * csize // comm.size
+        self._size =  end - start
+
+        self._rng = MPIRandomState(comm, seed, self._size)
 
         # init the base class
         CatalogSource.__init__(self, comm=comm)

--- a/nbodykit/tests/test_mpirng.py
+++ b/nbodykit/tests/test_mpirng.py
@@ -36,6 +36,16 @@ def test_mpirng_small_chunk(comm):
     assert_array_equal(all, correct)
 
 @MPITest([4])
+def test_mpirng_unique(comm):
+    rng = MPIRandomState(comm, seed=1234, size=10, chunksize=3)
+
+    local1 = rng.uniform()
+    local2 = rng.uniform()
+
+    # it shouldn't be the same!
+    assert (local1 != local2).any()
+
+@MPITest([4])
 def test_mpirng_args(comm):
     rng = MPIRandomState(comm, seed=1234, size=10, chunksize=3)
 

--- a/nbodykit/tests/test_mpirng.py
+++ b/nbodykit/tests/test_mpirng.py
@@ -1,0 +1,76 @@
+from runtests.mpi import MPITest
+from nbodykit import setup_logging
+from nbodykit.mpirng import MPIRandomState
+from numpy.testing import assert_array_equal
+import numpy
+from mpi4py import MPI
+import os
+import pytest
+
+setup_logging("debug")
+
+@MPITest([4])
+def test_mpirng_large_chunk(comm):
+    rng = MPIRandomState(comm, seed=1234, size=1, chunksize=10)
+
+    local = rng.uniform()
+    all = numpy.concatenate(comm.allgather(local), axis=0)
+
+    rng1 = MPIRandomState(MPI.COMM_SELF, seed=1234, size=rng.csize, chunksize=rng.chunksize)
+
+    correct = rng1.uniform()
+
+    assert_array_equal(all, correct)
+
+@MPITest([4])
+def test_mpirng_small_chunk(comm):
+    rng = MPIRandomState(comm, seed=1234, size=10, chunksize=3)
+
+    local = rng.uniform()
+    all = numpy.concatenate(comm.allgather(local), axis=0)
+
+    rng1 = MPIRandomState(MPI.COMM_SELF, seed=1234, size=rng.csize, chunksize=rng.chunksize)
+
+    correct = rng1.uniform()
+
+    assert_array_equal(all, correct)
+
+@MPITest([4])
+def test_mpirng_args(comm):
+    rng = MPIRandomState(comm, seed=1234, size=10, chunksize=3)
+
+    local = rng.uniform(low=numpy.ones(rng.size) * 0.5)
+    all = numpy.concatenate(comm.allgather(local), axis=0)
+
+    rng1 = MPIRandomState(MPI.COMM_SELF, seed=1234, size=rng.csize, chunksize=rng.chunksize)
+
+    correct = rng1.uniform(low=0.5)
+
+    assert_array_equal(all, correct)
+
+@MPITest([4])
+def test_mpirng_itemshape(comm):
+    rng = MPIRandomState(comm, seed=1234, size=10, chunksize=3)
+
+    local = rng.uniform(low=numpy.ones(rng.size)[:, None] * 0.5, itemshape=(3,))
+    all = numpy.concatenate(comm.allgather(local), axis=0)
+
+    rng1 = MPIRandomState(MPI.COMM_SELF, seed=1234, size=rng.csize, chunksize=rng.chunksize)
+
+    correct = rng1.uniform(low=0.5, itemshape=(3,))
+
+    assert_array_equal(all, correct)
+
+@MPITest([4])
+def test_mpirng_poisson(comm):
+    rng = MPIRandomState(comm, seed=1234, size=10, chunksize=3)
+
+    local = rng.poisson(lam=numpy.ones(rng.size)[:, None] * 0.5, itemshape=(3,))
+    all = numpy.concatenate(comm.allgather(local), axis=0)
+
+    rng1 = MPIRandomState(MPI.COMM_SELF, seed=1234, size=rng.csize, chunksize=rng.chunksize)
+
+    correct = rng1.poisson(lam=0.5, itemshape=(3,))
+
+    assert_array_equal(all, correct)
+

--- a/nbodykit/tests/test_transform.py
+++ b/nbodykit/tests/test_transform.py
@@ -17,9 +17,9 @@ def test_sky_to_cartesian(comm):
     s = RandomCatalog(csize=100, seed=42)
 
     # ra, dec, z
-    s['z']   = s.rng.normal(loc=0.5, scale=0.1, size=s.size)
-    s['ra']  = s.rng.uniform(low=110, high=260, size=s.size)
-    s['dec'] = s.rng.uniform(low=-3.6, high=60., size=s.size)
+    s['z']   = s.rng.normal(loc=0.5, scale=0.1)
+    s['ra']  = s.rng.uniform(low=110, high=260)
+    s['dec'] = s.rng.uniform(low=-3.6, high=60)
 
     # make the position array
     s['Position1'] = transform.SkyToCartesian(s['ra'], s['dec'], s['z'], cosmo)
@@ -98,9 +98,9 @@ def test_stack_columns(comm):
     s = RandomCatalog(csize=100, seed=42)
 
     # add x,y,z
-    s['x'] = s.rng.uniform(0, 2600., size=s.size)
-    s['y'] = s.rng.uniform(0, 2600., size=s.size)
-    s['z'] = s.rng.uniform(0, 2600., size=s.size)
+    s['x'] = s.rng.uniform(0, 2600.)
+    s['y'] = s.rng.uniform(0, 2600.)
+    s['z'] = s.rng.uniform(0, 2600.)
 
     # stack
     s['Position'] = transform.StackColumns(s['x'], s['y'], s['z'])

--- a/nbodykit/utils.py
+++ b/nbodykit/utils.py
@@ -342,7 +342,6 @@ def ScatterArray(data, comm, root=0, counts=None):
     dt.Free()
     return recvbuffer
 
-
 def FrontPadArray(array, front, comm):
     """ Padding an array in the front with items before this rank.
 
@@ -357,10 +356,11 @@ def FrontPadArray(array, front, comm):
     torecv[torecv > N] = N[torecv > N] # fully enclosed
 
     if comm.allreduce(torecv.sum() != front, MPI.LOR):
-        raise ValueError("cannot work out a plan to padd items. Some front values are too large. %d %d" % (torecv.sum(), front))
+        raise ValueError("cannot work out a plan to padd items. Some front values are too large. %d %d"
+            % (torecv.sum(), front))
 
     tosend = comm.alltoall(torecv)
-    sendbuf = [ array[-items:] if items > 0 else [] for i, items in enumerate(tosend)]
+    sendbuf = [ array[-items:] if items > 0 else array[0:0] for i, items in enumerate(tosend)]
     recvbuf = comm.alltoall(sendbuf)
     return numpy.concatenate(list(recvbuf) + [array], axis=0)
 

--- a/nbodykit/utils.py
+++ b/nbodykit/utils.py
@@ -343,6 +343,27 @@ def ScatterArray(data, comm, root=0, counts=None):
     return recvbuffer
 
 
+def FrontPadArray(array, front, comm):
+    """ Padding an array in the front with items before this rank.
+
+    """
+    N = numpy.array(comm.allgather(len(array)), dtype='intp')
+    offsets = numpy.cumsum(numpy.concatenate([[0], N], axis=0))
+    mystart = offsets[comm.rank] - front
+    torecv = (offsets[:-1] + N) - mystart
+
+    torecv[torecv < 0] = 0 # before mystart
+    torecv[torecv > front] = 0 # no more than needed
+    torecv[torecv > N] = N[torecv > N] # fully enclosed
+
+    if comm.allreduce(torecv.sum() != front, MPI.LOR):
+        raise ValueError("cannot work out a plan to padd items. Some front values are too large. %d %d" % (torecv.sum(), front))
+
+    tosend = comm.alltoall(torecv)
+    sendbuf = [ array[-items:] if items > 0 else [] for i, items in enumerate(tosend)]
+    recvbuf = comm.alltoall(sendbuf)
+    return numpy.concatenate(list(recvbuf) + [array], axis=0)
+
 def attrs_to_dict(obj, prefix):
     if not hasattr(obj, 'attrs'):
         return {}


### PR DESCRIPTION
This PR replaces #492 . The reason is this one relies on a different (cleaner) API in pmesh.
This API of pmesh exposes transposed / untransposed Fields as different subclasses of BaseComplexField, rather than requiring different pm objects.
