### PR TITLE
Add a take method to BinnedStatistic.

### DIFF
--- a/nbodykit/tests/test_binned_stat.py
+++ b/nbodykit/tests/test_binned_stat.py
@@ -191,11 +191,36 @@ def test_sel(comm):
     sliced = dataset.sel(k=[0.1], method='nearest')
     assert sliced.shape[0] == 1
 
+    # this return empty k with arbitary edges.
+    sliced = dataset.sel(k=[], method='nearest')
+    assert sliced.shape[0] == 0
+
     # slice in a specific k-range
     sliced = dataset.sel(k=slice(0.02, 0.15), mu=[0.5], method='nearest')
     assert sliced.shape[1] == 1
     assert numpy.alltrue((sliced['k'] >= 0.02)&(sliced['k'] <= 0.15))
 
+@MPITest([1])
+def test_take(comm):
+
+    dataset = BinnedStatistic.from_json(os.path.join(data_dir, 'dataset_2d.json'))
+
+    sliced = dataset.take(k=[8])
+    assert sliced.shape[0] == 1
+    assert len(sliced.dims) == 2
+
+    sliced = dataset.take(k=[])
+    assert sliced.shape[0] == 0
+    assert len(sliced.dims) == 2
+
+    dataset.take(k=dataset.coords['k'] < 0.3)
+    assert len(sliced.dims) == 2
+
+    dataset.take(dataset['modes'] > 0)
+    assert len(sliced.dims) == 2
+
+    dataset.take(dataset['k'] < 0.3)
+    assert len(sliced.dims) == 2
 
 @MPITest([1])
 def test_squeeze(comm):


### PR DESCRIPTION
The take method behaves more or less like the traditional numpy indexing.
Either a boolean mask of the same shape of data, or boolean masks along
each axis is accept. It is more powerful and sometimes allows more
intuitive code segments than the current sel method; see the example in
docstring.

The full boolean mask is projected along each axis then 'and'ed to the
given mask along the axis.

If a list of indices is given along any axis, it is first converted to
a mask.

In the end the booleans are converted to lists because the finalize method
takes only indices.