### PR TITLE
Add compute method and remove Catalog interface from CatalogMesh.

### DIFF
--- a/nbodykit/algorithms/fftpower.py
+++ b/nbodykit/algorithms/fftpower.py
@@ -97,13 +97,13 @@ class FFTBase(object):
         p3d : array_like (complex)
             the 3D complex array holding the power spectrum
         """
-        c1 = self.first.paint(mode='complex', Nmesh=self.attrs['Nmesh'])
+        c1 = self.first.compute(mode='complex', Nmesh=self.attrs['Nmesh'])
 
         # compute the auto power of single supplied field
         if self.first is self.second:
             c2 = c1
         else:
-            c2 = self.second.paint(mode='complex', Nmesh=self.attrs['Nmesh'])
+            c2 = self.second.compute(mode='complex', Nmesh=self.attrs['Nmesh'])
 
         # calculate the 3d power spectrum, slab-by-slab to save memory
         p3d = c1
@@ -356,13 +356,13 @@ class FFTPower(FFTBase):
         p3d : array_like (complex)
             the 3D complex array holding the power spectrum
         """
-        c1 = self.first.paint(mode='complex', Nmesh=self.attrs['Nmesh'])
+        c1 = self.first.compute(mode='complex', Nmesh=self.attrs['Nmesh'])
 
         # compute the auto power of single supplied field
         if self.first is self.second:
             c2 = c1
         else:
-            c2 = self.second.paint(mode='complex', Nmesh=self.attrs['Nmesh'])
+            c2 = self.second.compute(mode='complex', Nmesh=self.attrs['Nmesh'])
 
         # calculate the 3d power spectrum, slab-by-slab to save memory
         p3d = c1
@@ -476,7 +476,7 @@ class ProjectedFFTPower(FFTBase):
             - modes :
                 the number of Fourier modes averaged together in each bin
         """
-        c1 = self.first.paint(Nmesh=self.attrs['Nmesh'], mode='complex')
+        c1 = self.first.compute(Nmesh=self.attrs['Nmesh'], mode='complex')
         r1 = c1.preview(self.attrs['Nmesh'], axes=self.attrs['axes'])
         # average along projected axes;
         # part of product is the rfftn vs r2c (for axes)
@@ -487,7 +487,7 @@ class ProjectedFFTPower(FFTBase):
         if self.first is self.second:
             c2 = c1
         else:
-            c2 = self.second.paint(Nmesh=self.attrs['Nmesh'], mode='complex')
+            c2 = self.second.compute(Nmesh=self.attrs['Nmesh'], mode='complex')
             r2 = c2.preview(self.attrs['Nmesh'], axes=self.attrs['axes'])
             c2 = numpy.fft.rfftn(r2) / self.attrs['Nmesh'].prod() # average along projected axes
 

--- a/nbodykit/algorithms/fftrecon.py
+++ b/nbodykit/algorithms/fftrecon.py
@@ -132,7 +132,7 @@ class FFTRecon(MeshSource):
     def run(self):
 
         s_d, s_r = self._compute_s()
-        return self._paint(s_d, s_r)
+        return self._helper_paint(s_d, s_r)
 
     def work_with(self, cat, s):
         pm = self.pm
@@ -167,7 +167,7 @@ class FFTRecon(MeshSource):
             self.logger.info("painted %s, mean=%g" % (name, cmean))
 
 
-    def _paint(self, s_d, s_r):
+    def _helper_paint(self, s_d, s_r):
         """ Convert the displacements of data and random to a single reconstruction mesh object. """
 
         def LGS(delta_s_r):

--- a/nbodykit/base/mesh.py
+++ b/nbodykit/base/mesh.py
@@ -281,7 +281,6 @@ class MeshSource(object):
         else:
             attrs = var.attrs
 
-        print('_paint', actions)
         for action in actions:
             # ensure var is the right mode
 

--- a/nbodykit/base/mesh.py
+++ b/nbodykit/base/mesh.py
@@ -1,6 +1,7 @@
 import numpy
 import logging
 from pmesh.pm import ParticleMesh, RealField, BaseComplexField
+import warnings
 
 class MeshSource(object):
     """
@@ -230,7 +231,17 @@ class MeshSource(object):
 
         return var
 
+    def compute(self, mode='real', Nmesh=None):
+        """
+            Compute / Fetch the mesh object into memory as a RealField or ComplexField object.
+        """
+        return self._paint_XXX(mode=mode, Nmesh=Nmesh)
+
     def paint(self, mode="real", Nmesh=None):
+        warnings.warn("the paint method is deprecated from the Public API. Use .compute() instead.", DeprecationWarning)
+        return self._paint_XXX(mode=mode, Nmesh=Nmesh)
+
+    def _paint_XXX(self, mode="real", Nmesh=None):
         """
         Paint the density on the mesh and apply
         any transformation functions specified in :attr:`actions`.
@@ -270,6 +281,7 @@ class MeshSource(object):
         else:
             attrs = var.attrs
 
+        print('_paint', actions)
         for action in actions:
             # ensure var is the right mode
 
@@ -360,7 +372,7 @@ class MeshSource(object):
         import json
         from nbodykit.utils import JSONEncoder
 
-        field = self.paint(mode=mode)
+        field = self.compute(mode=mode)
 
         with bigfile.BigFileMPI(self.pm.comm, output, create=True) as ff:
             data = numpy.empty(shape=field.size, dtype=field.dtype)

--- a/nbodykit/base/tests/test_catalog.py
+++ b/nbodykit/base/tests/test_catalog.py
@@ -78,10 +78,8 @@ def test_tomesh(comm):
     source['Weight2'] = source['Velocity'][:, 2]
 
     mesh = source.to_mesh(Nmesh=128, compensated=True)
-    assert_allclose(source['Position'], mesh['Position'])
 
     mesh = source.to_mesh(Nmesh=128, compensated=True, interlaced=True)
-    assert_allclose(source['Position'], mesh['Position'])
 
     mesh = source.to_mesh(Nmesh=128, weight='Weight0')
 

--- a/nbodykit/base/tests/test_catalogmesh.py
+++ b/nbodykit/base/tests/test_catalogmesh.py
@@ -84,10 +84,10 @@ def test_paint_chunksize(comm):
     mesh = source.to_mesh(window='tsc', Nmesh=64, interlaced=True, compensated=True)
 
     with set_options(paint_chunk_size=source.csize // 4):
-        r1 = mesh.paint()
+        r1 = mesh.compute()
 
     with set_options(paint_chunk_size=source.csize):
-        r2 = mesh.paint()
+        r2 = mesh.compute()
 
     assert_allclose(r1, r2)
 
@@ -153,37 +153,6 @@ def test_no_compensation(comm):
     # cannot compute compensation
     with pytest.raises(ValueError):
         actions = mesh.actions
-
-@MPITest([1, 4])
-def test_copy(comm):
-
-    CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=0.2e-3, BoxSize=1024., seed=42)
-    source['TEST'] = 10
-    source.attrs['TEST'] = 'TEST'
-
-    # make the mesh
-    source = source.to_mesh(Nmesh=32)
-
-    # store original data
-    data = {}
-    for col in source:
-        data[col] = source[col].compute()
-
-    # make copy
-    copy = source.copy()
-
-    # modify original
-    source['Position'] += 100.
-    source['Velocity'] *= 10.
-
-    # check data is equal to original
-    for col in copy:
-        assert_array_equal(copy[col].compute(), data[col])
-
-    # check meta-data
-    for k in source.attrs:
-        assert k in copy.attrs
 
 @MPITest([4])
 def test_slice(comm):
@@ -251,7 +220,7 @@ def test_apply_nocompensation(comm):
     mesh = mesh.apply(raisefunc)
 
     with pytest.raises(StopIteration):
-        mesh.paint()
+        mesh.compute()
 
     # view
     view = mesh.view()
@@ -281,5 +250,5 @@ def test_apply_compensated(comm):
     mesh = mesh.apply(raisefunc)
 
     with pytest.raises(StopIteration):
-        mesh.paint()
+        mesh.compute()
 

--- a/nbodykit/base/tests/test_mesh.py
+++ b/nbodykit/base/tests/test_mesh.py
@@ -69,7 +69,7 @@ def test_real_save(comm):
         assert_array_equal(source2.attrs[k], source.attrs[k])
 
     # check data
-    assert_array_equal(source2.paint(mode='complex'), source.paint(mode='complex'))
+    assert_array_equal(source2.compute(mode='complex'), source.compute(mode='complex'))
 
     # cleanup
     comm.barrier()
@@ -107,7 +107,7 @@ def test_real_save(comm):
         assert_array_equal(source2.attrs[k], source.attrs[k])
 
     # check data
-    assert_array_equal(source2.paint(mode='real'), source.paint(mode='real'))
+    assert_array_equal(source2.compute(mode='real'), source.compute(mode='real'))
 
     # cleanup
     comm.barrier()
@@ -125,7 +125,7 @@ def test_preview(comm):
     source = LinearMesh(Plin, Nmesh=64, BoxSize=512, seed=42)
 
     # the painted RealField
-    real = source.paint(mode='real')
+    real = source.compute(mode='real')
 
     preview = source.preview()
     assert_allclose(preview.sum(), real.csum(), rtol=1e-5)
@@ -145,7 +145,7 @@ def test_resample(comm):
     source = LinearMesh(Plin, Nmesh=64, BoxSize=512, seed=42)
 
     # re-sample to Nmesh=32
-    real = source.paint(mode='real', Nmesh=32)
+    real = source.compute(mode='real', Nmesh=32)
 
     # and preview at same resolution
     preview = source.preview(Nmesh=32)
@@ -172,7 +172,7 @@ def test_bad_mode(comm):
         field = source.to_field(mode='BAD')
 
     with pytest.raises(ValueError):
-        field = source.paint(mode='BAD')
+        field = source.compute(mode='BAD')
 
 @MPITest([4])
 def test_view(comm):

--- a/nbodykit/source/catalog/tests/test_lognormal.py
+++ b/nbodykit/source/catalog/tests/test_lognormal.py
@@ -20,7 +20,7 @@ def test_lognormal_sparse(comm):
 
     mesh = source.to_mesh(compensated=False)
 
-    real = mesh.paint(mode='real')
+    real = mesh.compute(mode='real')
     assert_allclose(real.cmean(), 1.0)
 
 @MPITest([1, 4])
@@ -32,7 +32,7 @@ def test_lognormal_dense(comm):
     source = LogNormalCatalog(Plin=Plin, nbar=0.2e-2, BoxSize=128., Nmesh=8, seed=42)
     mesh = source.to_mesh(compensated=False)
 
-    real = mesh.paint(mode='real')
+    real = mesh.compute(mode='real')
     assert_allclose(real.cmean(), 1.0, rtol=1e-5)
 
 @MPITest([4])
@@ -62,7 +62,7 @@ def test_lognormal_velocity(comm):
     source['Value'] = source['Velocity'][:, 0]**2
     mesh = source.to_mesh(compensated=False)
 
-    real = mesh.paint(mode='real')
+    real = mesh.compute(mode='real')
     velsum = comm.allreduce((source['Velocity'][:, 0]**2).sum().compute())
     velmean = velsum / source.csize
 

--- a/nbodykit/source/catalogmesh/tests/test_fkp.py
+++ b/nbodykit/source/catalogmesh/tests/test_fkp.py
@@ -43,12 +43,12 @@ def test_paint(comm):
     mesh2 = source2.to_mesh(Nmesh=32, BoxSize=512)
 
     # update weights for source1 and source2
-    mesh1['Weight'] *= mesh1['FKPWeight']
-    mesh2['Weight'] *= mesh2['FKPWeight']
+    mesh1.source['Weight'] *= mesh1.source['FKPWeight']
+    mesh2.source['Weight'] *= mesh2.source['FKPWeight']
 
     # paint the re-centered Position
-    mesh1['Position'] -= mesh.attrs['BoxCenter']
-    mesh2['Position'] -= mesh.attrs['BoxCenter']
+    mesh1.source['Position'] -= mesh.attrs['BoxCenter']
+    mesh2.source['Position'] -= mesh.attrs['BoxCenter']
 
     # alpha is the sum of Weight
     alpha = 1. * source1.csize * WEIGHT1 / (source2.csize * WEIGHT2)

--- a/nbodykit/source/catalogmesh/tests/test_species.py
+++ b/nbodykit/source/catalogmesh/tests/test_species.py
@@ -44,12 +44,10 @@ def test_getitem(comm):
 
     for source, name in zip([source1, source2], ['data', 'randoms']):
         submesh = mesh[name] # should be equal to source
-        for col in source:
-            assert col in submesh
-            assert_array_equal(submesh[col].compute(), source[col].compute())
+        assert submesh.source is cat[name]
 
 @MPITest([1, 4])
-def test_paint(comm):
+def test_compute(comm):
 
     CurrentMPIComm.set(comm)
 
@@ -111,7 +109,7 @@ def test_paint_interlaced(comm):
 
     # the combined density field
     #combined = mesh.to_real_field()
-    combined = mesh.paint()
+    combined = mesh.compute()
 
     assert_allclose(combined.cmean(), 1.0)
     # must be the same

--- a/nbodykit/source/mesh/tests/test_bigfile.py
+++ b/nbodykit/source/mesh/tests/test_bigfile.py
@@ -19,8 +19,8 @@ def test_bigfile_grid(comm):
     Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
     source = LinearMesh(Plin, BoxSize=512, Nmesh=64, seed=42)
 
-    real = source.paint(mode='real')
-    complex = source.paint(mode="complex")
+    real = source.compute(mode='real')
+    complex = source.compute(mode="complex")
 
     # and save to tmp directory
     if comm.rank == 0:
@@ -33,7 +33,7 @@ def test_bigfile_grid(comm):
 
     # now load it and paint to the algorithm's ParticleMesh
     source = BigFileMesh(path=output, dataset='Field')
-    loaded_real = source.paint()
+    loaded_real = source.compute()
 
     # compare to direct algorithm result
     assert_array_equal(real, loaded_real)
@@ -42,7 +42,7 @@ def test_bigfile_grid(comm):
 
     # now load it and paint to the algorithm's ParticleMesh
     source = BigFileMesh(path=output, dataset='FieldC')
-    loaded_real = source.paint(mode="complex")
+    loaded_real = source.compute(mode="complex")
 
     # compare to direct algorithm result
     assert_allclose(complex, loaded_real, atol=1e-7)

--- a/nbodykit/tests/test_lab.py
+++ b/nbodykit/tests/test_lab.py
@@ -26,7 +26,7 @@ def test_fftpower(comm):
     result.save(output)
 
 @MPITest([1, 4])
-def test_paint(comm):
+def test_compute(comm):
     cosmo = cosmology.Planck15
 
     CurrentMPIComm.set(comm)
@@ -48,8 +48,8 @@ def test_paint(comm):
 
     source = source.apply(filter)
 
-    real = source.paint(mode='real')
-    complex = source.paint(mode='complex')
+    real = source.compute(mode='real')
+    complex = source.compute(mode='complex')
 
     source.save(output="./test_paint-real-%d.bigfile" % comm.size, mode='real')
     source.save(output="./test_paint-complex-%d.bigfile" % comm.size, mode='complex')


### PR DESCRIPTION
This is required to add a compute method to MeshSource. Because
if CatalogMesh is a CatalogSource then CatalogSource.compute comes
into the way.

I think this PR also sheds some light on how to deal with the temporary
variables created during FKP/convpower. They probably shall be saved
as attributes of the CatalogMesh objects directly, rather than stored
as columns of the underlying sources.