### PR TITLE
FFTPower and FFTCorr supports Unique |k| or |r| bins. 

### DIFF
--- a/nbodykit/algorithms/fftpower.py
+++ b/nbodykit/algorithms/fftpower.py
@@ -176,7 +176,8 @@ class FFTPower(FFTBase):
         if `mode = 1d`, then ``Nmu`` is set to 1
     dk : float, optional
         the linear spacing of ``k`` bins to use; if not provided, the
-        fundamental mode  of the box is used
+        fundamental mode  of the box is used; if `dk=0` is set, use fine bins
+        such that the modes contributing to the bin has identical modulus.
     kmin : float, optional
         the lower edge of the first ``k`` bin to use
     poles : list of int, optional
@@ -223,14 +224,11 @@ class FFTPower(FFTBase):
         function returns nothing, but attaches several attributes
         to the class:
 
-        - :attr:`edges`
         - :attr:`power`
         - :attr:`poles`
 
         Attributes
         ----------
-        edges : array_like
-            the edges of the wavenumber bins
         power : :class:`~nbodykit.binned_statistic.BinnedStatistic`
             a BinnedStatistic object that holds the measured :math:`P(k)` or
             :math:`P(k,\mu)`. It stores the following variables:
@@ -283,11 +281,16 @@ class FFTPower(FFTBase):
         # (accounting for possibly anisotropic box)
         dk = self.attrs['dk']
         kmin = self.attrs['kmin']
-        kedges = numpy.arange(kmin, numpy.pi*y3d.Nmesh.min()/y3d.BoxSize.max() + dk/2, dk)
+        if dk > 0:
+            kedges = numpy.arange(kmin, numpy.pi*y3d.Nmesh.min()/y3d.BoxSize.max() + dk/2, dk)
+            kcoords = None
+        else:
+            kedges, kcoords = _find_unique_edges(y3d.x, 2 * numpy.pi / y3d.BoxSize, y3d.pm.comm)
 
         # project on to the desired basis
         muedges = numpy.linspace(0, 1, self.attrs['Nmu']+1, endpoint=True)
         edges = [kedges, muedges]
+        coords = [kcoords, None]
         result, pole_result = project_to_basis(y3d, edges,
                                                poles=self.attrs['poles'],
                                                los=self.attrs['los'])
@@ -296,7 +299,8 @@ class FFTPower(FFTBase):
         if self.attrs['mode'] == "1d":
             cols = ['k', 'power', 'modes']
             icols = [0, 2, 3]
-            edges = edges[0]
+            edges = edges[0:1]
+            coords = coords[0:1]
         else:
             cols = ['k', 'mu', 'power', 'modes']
             icols = [0, 1, 2, 3]
@@ -319,34 +323,32 @@ class FFTPower(FFTBase):
             for icol, col in enumerate(cols):
                 poles[col][:] = result[icol]
 
-        # set all the necessary results
-        self.edges = edges
-        self.poles = poles
-        self.power = power
-
-        self._make_datasets()
+        self.power, self.poles = self._make_datasets(edges, poles, power, coords)
 
     def __getstate__(self):
         state = dict(
-                     edges=self.edges,
-                     power=self.power.data,
-                     poles=getattr(self.poles, 'data', None),
-                     attrs=self.attrs)
+                    power=self.power.__getstate__(),
+                    poles=self.poles.__getstate__() if self.poles is not None else None,
+                    attrs=self.attrs)
         return state
 
     def __setstate__(self, state):
-        self.__dict__.update(state)
-        self._make_datasets()
+        self.attrs = state['attrs']
+        self.power = BinnedStatistic.from_state(state['power'])
+        if state['poles'] is not None:
+            self.poles = BinnedStatistic.from_state(state['poles'])
 
-    def _make_datasets(self):
+    def _make_datasets(self, edges, poles, power, coords):
 
         if self.attrs['mode'] == '1d':
-            self.power = BinnedStatistic(['k'], [self.edges], self.power, fields_to_sum=['modes'], **self.attrs)
+            power = BinnedStatistic(['k'], edges, power, fields_to_sum=['modes'], coords=coords, **self.attrs)
         else:
-            self.power = BinnedStatistic(['k', 'mu'], self.edges, self.power, fields_to_sum=['modes'], **self.attrs)
-        if self.poles is not None:
-            self.poles = BinnedStatistic(['k'], [self.power.edges['k']], self.poles, fields_to_sum=['modes'], **self.attrs)
+            power = BinnedStatistic(['k', 'mu'], edges, power, fields_to_sum=['modes'], coords=coords, **self.attrs)
 
+        if poles is not None:
+            poles = BinnedStatistic(['k'], [power.edges['k']], poles, fields_to_sum=['modes'], coords=[power.coords['k']], **self.attrs)
+
+        return power, poles
     def _compute_3d_power(self):
         """
         Compute and return the 3D power from two input sources
@@ -769,3 +771,38 @@ def _cast_source(source, BoxSize, Nmesh):
                           "`Nmesh` as keyword of to_mesh()"))
 
     return source
+
+def _find_unique_edges(x, x0, comm):
+    """ Construct unique edges based on x0.
+
+        The modes along each direction are assumed to be multiples of x0
+
+        Returns edges and the true centers
+    """
+    def find_unique(x, x0):
+        fx2 = 0
+        for xi, x0i in zip(x, x0):
+            fx2 = fx2 + xi ** 2
+
+        fx2 = numpy.ravel(fx2)
+        ix2 = numpy.int64(fx2 / (x0.min() * 0.5) ** 2 + 0.5)
+        ix2, ind = numpy.unique(ix2, return_index=True)
+        fx2 = fx2[ind]
+        return fx2 ** 0.5
+
+    fx = find_unique(x, x0)
+
+    fx = numpy.concatenate(comm.allgather(fx), axis=0)
+    # may have duplicates after allgather
+    fx = numpy.unique(fx)
+    fx.sort()
+
+    # now make some reasonable bins.
+    width = numpy.diff(fx)
+    edges = fx.copy()
+    edges[1:] -= width * 0.5
+    edges = numpy.append(edges, [fx[-1] + width[-1] * 0.5])
+    edges[0] = 0
+
+    # fx is the 'true' centers, up to round-off errors.
+    return edges, fx

--- a/nbodykit/algorithms/fftpower.py
+++ b/nbodykit/algorithms/fftpower.py
@@ -88,22 +88,28 @@ class FFTBase(object):
 
         return self
 
-    def _compute_3d_power(self):
+    def _compute_3d_power(self, first, second):
         """
-        Compute and return the 3D power from two input sources
+        Compute and return the power as a function of k vector, for two input sources
 
         Returns
         -------
         p3d : array_like (complex)
             the 3D complex array holding the power spectrum
+        attrs : dict
+            meta data of the 3d power
         """
-        c1 = self.first.compute(mode='complex', Nmesh=self.attrs['Nmesh'])
+        attrs = {}
+        # add self.attrs
+        attrs.update(self.attrs)
+
+        c1 = first.compute(mode='complex', Nmesh=self.attrs['Nmesh'])
 
         # compute the auto power of single supplied field
-        if self.first is self.second:
+        if first is second:
             c2 = c1
         else:
-            c2 = self.second.compute(mode='complex', Nmesh=self.attrs['Nmesh'])
+            c2 = second.compute(mode='complex', Nmesh=self.attrs['Nmesh'])
 
         # calculate the 3d power spectrum, slab-by-slab to save memory
         p3d = c1
@@ -124,7 +130,7 @@ class FFTBase(object):
         # get the number of objects (in a safe manner)
         N1 = c1.attrs.get('N', 0)
         N2 = c2.attrs.get('N', 0)
-        self.attrs.update({'N1':N1, 'N2':N2})
+        attrs.update({'N1':N1, 'N2':N2})
 
         # add shotnoise (nonzero only for auto-spectra)
         Pshot = 0
@@ -136,9 +142,11 @@ class FFTBase(object):
                                    "of discrete data in FFTPower"))
             else:
                 Pshot = c1.attrs['shotnoise']
-        self.attrs['shotnoise'] = Pshot
+        attrs['shotnoise'] = Pshot
 
-        return p3d
+
+        return p3d, attrs
+
 
 class FFTPower(FFTBase):
     """
@@ -216,19 +224,17 @@ class FFTPower(FFTBase):
         self.attrs['dk'] = dk
         self.attrs['kmin'] = kmin
 
-        self.run()
+        self.power, self.poles = self.run()
+
+        # for compatibility, copy power's attrs into self.
+        self.attrs.update(self.power.attrs)
 
     def run(self):
         """
-        Compute the power spectrum in a periodic box, using FFTs. This
-        function returns nothing, but attaches several attributes
-        to the class:
+        Compute the power spectrum in a periodic box, using FFTs.
 
-        - :attr:`power`
-        - :attr:`poles`
-
-        Attributes
-        ----------
+        Returns 
+        -------
         power : :class:`~nbodykit.binned_statistic.BinnedStatistic`
             a BinnedStatistic object that holds the measured :math:`P(k)` or
             :math:`P(k,\mu)`. It stores the following variables:
@@ -255,7 +261,7 @@ class FFTPower(FFTBase):
             - modes :
                 the number of Fourier modes averaged together in each bin
 
-        attrs : dict
+        power.attrs, poles.attrs : dict
             dictionary of meta-data; in addition to storing the input parameters,
             it includes the following fields computed during the algorithm
             execution:
@@ -275,7 +281,7 @@ class FFTPower(FFTBase):
         if self.attrs['mode'] == "1d": self.attrs['Nmu'] = 1
 
         # measure the 3D power (y3d is a ComplexField)
-        y3d = self._compute_3d_power()
+        y3d, attrs = self._compute_3d_power(self.first, self.second)
 
         # binning in k out to the minimum nyquist frequency
         # (accounting for possibly anisotropic box)
@@ -323,7 +329,7 @@ class FFTPower(FFTBase):
             for icol, col in enumerate(cols):
                 poles[col][:] = result[icol]
 
-        self.power, self.poles = self._make_datasets(edges, poles, power, coords)
+        return self._make_datasets(edges, poles, power, coords, attrs)
 
     def __getstate__(self):
         state = dict(
@@ -338,68 +344,17 @@ class FFTPower(FFTBase):
         if state['poles'] is not None:
             self.poles = BinnedStatistic.from_state(state['poles'])
 
-    def _make_datasets(self, edges, poles, power, coords):
+    def _make_datasets(self, edges, poles, power, coords, attrs):
 
         if self.attrs['mode'] == '1d':
-            power = BinnedStatistic(['k'], edges, power, fields_to_sum=['modes'], coords=coords, **self.attrs)
+            power = BinnedStatistic(['k'], edges, power, fields_to_sum=['modes'], coords=coords, **attrs)
         else:
-            power = BinnedStatistic(['k', 'mu'], edges, power, fields_to_sum=['modes'], coords=coords, **self.attrs)
+            power = BinnedStatistic(['k', 'mu'], edges, power, fields_to_sum=['modes'], coords=coords, **attrs)
 
         if poles is not None:
-            poles = BinnedStatistic(['k'], [power.edges['k']], poles, fields_to_sum=['modes'], coords=[power.coords['k']], **self.attrs)
+            poles = BinnedStatistic(['k'], [power.edges['k']], poles, fields_to_sum=['modes'], coords=[power.coords['k']], **attrs)
 
         return power, poles
-    def _compute_3d_power(self):
-        """
-        Compute and return the 3D power from two input sources
-
-        Returns
-        -------
-        p3d : array_like (complex)
-            the 3D complex array holding the power spectrum
-        """
-        c1 = self.first.compute(mode='complex', Nmesh=self.attrs['Nmesh'])
-
-        # compute the auto power of single supplied field
-        if self.first is self.second:
-            c2 = c1
-        else:
-            c2 = self.second.compute(mode='complex', Nmesh=self.attrs['Nmesh'])
-
-        # calculate the 3d power spectrum, slab-by-slab to save memory
-        p3d = c1
-        for (s0, s1, s2) in zip(p3d.slabs, c1.slabs, c2.slabs):
-            s0[...] = s1 * s2.conj()
-
-        for i, s0 in zip(p3d.slabs.i, p3d.slabs):
-            # clear the zero mode.
-            mask = True
-            for i1 in i:
-                mask = mask & (i1 == 0)
-            s0[mask] = 0
-
-        # the complex field is dimensionless; power is L^3
-        # ref to http://icc.dur.ac.uk/~tt/Lectures/UA/L4/cosmology.pdf
-        p3d[...] *= self.attrs['BoxSize'].prod()
-
-        # get the number of objects (in a safe manner)
-        N1 = c1.attrs.get('N', 0)
-        N2 = c2.attrs.get('N', 0)
-        self.attrs.update({'N1':N1, 'N2':N2})
-
-        # add shotnoise (nonzero only for auto-spectra)
-        Pshot = 0
-        if self.first is self.second:
-            if 'shotnoise' not in c1.attrs:
-                if isinstance(self.first, CatalogMesh):
-                    import warnings
-                    warnings.warn(("no 'shotnoise' found for auto power spectrum "
-                                   "of discrete data in FFTPower"))
-            else:
-                Pshot = c1.attrs['shotnoise']
-        self.attrs['shotnoise'] = Pshot
-
-        return p3d
 
 class ProjectedFFTPower(FFTBase):
     """

--- a/nbodykit/algorithms/tests/test_fftcorr.py
+++ b/nbodykit/algorithms/tests/test_fftcorr.py
@@ -23,16 +23,15 @@ def test_fftcorr_poles(comm):
     assert_array_equal(modes_1d, r.poles['modes'])
     assert_allclose(mono_from_pkmu, mono)
 
-
 @MPITest([1])
-def test_fftcorr_padding(comm):
+def test_fftcorr_unique(comm):
 
     CurrentMPIComm.set(comm)
     source = UniformCatalog(nbar=3e-3, BoxSize=512., seed=42)
 
-    r = FFTCorr(source, mode='1d', BoxSize=1024, Nmesh=32)
-    assert r.attrs['N1'] != 0
-    assert r.attrs['N2'] != 0
+    r = FFTCorr(source, mode='1d', Nmesh=32, dr=0)
+    p = r.corr
+    assert_allclose(p.coords['r'], p['r'], rtol=1e-6)
 
 @MPITest([1])
 def test_fftcorr_padding(comm):

--- a/nbodykit/algorithms/tests/test_fftpower.py
+++ b/nbodykit/algorithms/tests/test_fftpower.py
@@ -60,16 +60,15 @@ def test_fftpower_poles(comm):
     assert_array_equal(modes_1d, r.poles['modes'])
     assert_allclose(mono_from_pkmu, mono)
 
-
 @MPITest([1])
-def test_fftpower_padding(comm):
+def test_fftpower_unique(comm):
 
     CurrentMPIComm.set(comm)
     source = UniformCatalog(nbar=3e-3, BoxSize=512., seed=42)
 
-    r = FFTPower(source, mode='1d', BoxSize=1024, Nmesh=32)
-    assert r.attrs['N1'] != 0
-    assert r.attrs['N2'] != 0
+    r = FFTPower(source, mode='1d', Nmesh=32, dk=0)
+    p = r.power
+    assert_allclose(p.coords['k'], p['k'], rtol=1e-6)
 
 @MPITest([1])
 def test_fftpower_padding(comm):

--- a/nbodykit/base/tests/test_catalog.py
+++ b/nbodykit/base/tests/test_catalog.py
@@ -39,7 +39,7 @@ def test_save(comm):
     tmpfile = comm.bcast(tmpfile)
 
     # initialize a uniform catalog
-    source = UniformCatalog(nbar=0.2e-2, BoxSize=1024., seed=42)
+    source = UniformCatalog(nbar=0.2e-3, BoxSize=512., seed=42)
 
     # add a non-array attrs (saved as JSON)
     source.attrs['empty'] = None
@@ -72,7 +72,7 @@ def test_save(comm):
 def test_tomesh(comm):
     CurrentMPIComm.set(comm)
 
-    source = UniformCatalog(nbar=0.2e-2, BoxSize=1024., seed=42)
+    source = UniformCatalog(nbar=0.2e-2, BoxSize=512., seed=42)
     source['Weight0'] = source['Velocity'][:, 0]
     source['Weight1'] = source['Velocity'][:, 1]
     source['Weight2'] = source['Velocity'][:, 2]
@@ -103,7 +103,7 @@ def test_tomesh(comm):
 @MPITest([4])
 def test_bad_column(comm):
     CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=0.2e-3, BoxSize=1024., seed=42)
+    source = UniformCatalog(nbar=0.2e-3, BoxSize=512., seed=42)
 
     # read a missing column
     with pytest.raises(ValueError):
@@ -117,7 +117,7 @@ def test_bad_column(comm):
 def test_empty_slice(comm):
     CurrentMPIComm.set(comm)
 
-    source = UniformCatalog(nbar=0.2e-3, BoxSize=1024., seed=42)
+    source = UniformCatalog(nbar=0.2e-3, BoxSize=512., seed=42)
 
     # empty slice returns self
     source2 = source[source['Selection']]
@@ -137,7 +137,7 @@ def test_empty_slice(comm):
 def test_slice(comm):
     CurrentMPIComm.set(comm)
 
-    source = UniformCatalog(nbar=0.2e-3, BoxSize=1024., seed=42)
+    source = UniformCatalog(nbar=0.2e-3, BoxSize=512., seed=42)
 
     # slice a subset
     subset = source[:10]
@@ -161,7 +161,7 @@ def test_slice(comm):
 def test_dask_slice(comm):
     CurrentMPIComm.set(comm)
 
-    source = UniformCatalog(nbar=0.2e-3, BoxSize=1024., seed=42)
+    source = UniformCatalog(nbar=0.2e-3, BoxSize=512., seed=42)
 
     # add a selection column
     index = numpy.random.choice([True, False], size=len(source))
@@ -176,7 +176,7 @@ def test_dask_slice(comm):
 def test_index(comm):
     CurrentMPIComm.set(comm)
 
-    source = UniformCatalog(nbar=0.2e-3, BoxSize=1024., seed=42)
+    source = UniformCatalog(nbar=0.2e-3, BoxSize=512., seed=42)
     r = numpy.concatenate(comm.allgather(source.Index.compute()))
     assert_array_equal(r, range(source.csize))
 
@@ -211,7 +211,7 @@ def test_transform(comm):
 def test_getitem_columns(comm):
     CurrentMPIComm.set(comm)
 
-    source = UniformCatalog(nbar=0.2e-3, BoxSize=1024., seed=42)
+    source = UniformCatalog(nbar=0.2e-3, BoxSize=512., seed=42)
 
     # bad column name
     with pytest.raises(KeyError):
@@ -226,7 +226,7 @@ def test_getitem_columns(comm):
 def test_delitem(comm):
 
     CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=0.2e-3, BoxSize=1024., seed=42)
+    source = UniformCatalog(nbar=0.2e-3, BoxSize=512., seed=42)
 
     # add a test column
     test = numpy.ones(source.size)
@@ -246,7 +246,7 @@ def test_delitem(comm):
 
 def test_columnaccessor():
     from nbodykit.base.catalog import ColumnAccessor
-    source = UniformCatalog(nbar=0.2e-3, BoxSize=1024., seed=42)
+    source = UniformCatalog(nbar=0.2e-3, BoxSize=512., seed=42)
 
     c = source['Position']
     truth = c[0].compute()
@@ -279,7 +279,7 @@ def test_columnaccessor():
 def test_copy(comm):
 
     CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=0.2e-3, BoxSize=1024., seed=42)
+    source = UniformCatalog(nbar=0.2e-3, BoxSize=512., seed=42)
     source['TEST'] = 10
     source.attrs['TEST'] = 'TEST'
 
@@ -316,7 +316,7 @@ def test_view(comm):
     CurrentMPIComm.set(comm)
 
     # the CatalogSource
-    source = UniformCatalog(nbar=0.2e-3, BoxSize=1024., seed=42)
+    source = UniformCatalog(nbar=0.2e-3, BoxSize=512., seed=42)
     source['TEST'] = 10.
     source.attrs['TEST'] = 10.0
 


### PR DESCRIPTION
This PR also changes the file format of FFTPower.save and FFTCorr.save,
as they now also need to save the centers, which are no longer strictly
derived from the edges.

BinnedStatistic is extended to accept bin label coordinates as an external
argument. Of course rebinning would totally mess up the centers.

ProjectedFFTPower is left unchanged because it may eventually be rewritten with
the new 'transpose interface' of pmesh and improved support on 2d / 1d.

The edge property on FFTPower and FFTCorr, attached by the run method are now
removed. Use the edge property of the power object and corr object instead.

The 'run' function of FFTPower and FFTCorr are changed to be more 'function' like.