### PR TITLE
Domain Decompose of a catalog

### DIFF
--- a/nbodykit/base/catalog.py
+++ b/nbodykit/base/catalog.py
@@ -670,13 +670,12 @@ class CatalogSourceBase(object):
         # attach the necessary attributes from self
         return obj.__finalize__(self)
 
-    def decompose(self, domain, position='Position', freeze=[]):
+    def decompose(self, domain, position='Position', columns=None):
         """
         Domain Decompose a catalog, sending items to the ranks according to the
         supplied domain object. Using the `position` column as the Position.
 
-        This will read in the full position and create a rather large O(size) per rank
-        object to host which rank hosts which object.
+        This will read in the full position array and all of the requested columns.
 
         Parameters
         ----------
@@ -687,9 +686,9 @@ class CatalogSourceBase(object):
         position : string_like
             column to use to compute the position.
 
-        freeze: list of string_like
-            column to 'freeze', these will be pre-exchanged such that they
-            no longer need to be exchanged per request.
+        columns: list of string_like
+            columns to include in the new catalog, if not supplied, all catalogs
+            will be exchanged.
 
         Returns
         -------
@@ -700,7 +699,7 @@ class CatalogSourceBase(object):
             `self.attrs` are carried over as a shallow copy to the returned object.
         """
         from nbodykit.base.decomposed import DecomposedCatalog
-        return DecomposedCatalog(self, domain=domain, position=position, freeze=freeze)
+        return DecomposedCatalog(self, domain=domain, position=position, columns=columns)
 
     def to_mesh(self, Nmesh=None, BoxSize=None, dtype='f4', interlaced=False,
                 compensated=False, window='cic', weight='Weight',

--- a/nbodykit/base/catalog.py
+++ b/nbodykit/base/catalog.py
@@ -670,6 +670,38 @@ class CatalogSourceBase(object):
         # attach the necessary attributes from self
         return obj.__finalize__(self)
 
+    def decompose(self, domain, position='Position', freeze=[]):
+        """
+        Domain Decompose a catalog, sending items to the ranks according to the
+        supplied domain object. Using the `position` column as the Position.
+
+        This will read in the full position and create a rather large O(size) per rank
+        object to host which rank hosts which object.
+
+        Parameters
+        ----------
+        domain : :pyclass:`pmesh.domain.GridND` object
+            An easiest way to find a domain object is to use `pm.domain`, where `pm`
+            is a :pyclass:`pmesh.pm.ParticleMesh` object.
+
+        position : string_like
+            column to use to compute the position.
+
+        freeze: list of string_like
+            column to 'freeze', these will be pre-exchanged such that they
+            no longer need to be exchanged per request.
+
+        Returns
+        -------
+        CatalogSource
+            A decomposed catalog source, where each rank only contains objects
+            belongs to the rank as claimed by the domain object.
+
+            `self.attrs` are carried over as a shallow copy to the returned object.
+        """
+        from nbodykit.base.decomposed import DecomposedCatalog
+        return DecomposedCatalog(self, domain=domain, position=position, freeze=freeze)
+
     def to_mesh(self, Nmesh=None, BoxSize=None, dtype='f4', interlaced=False,
                 compensated=False, window='cic', weight='Weight',
                 value='Value', selection='Selection', position='Position'):

--- a/nbodykit/base/decomposed.py
+++ b/nbodykit/base/decomposed.py
@@ -1,0 +1,46 @@
+from nbodykit.base.catalog import CatalogSource
+
+class DecomposedCatalog(CatalogSource):
+    """ A DomainDecomposedCatalog.
+
+        Attributes
+        ----------
+        domain : :pyclass:`pmesh.domain.GridND`
+        layout : A large object that holds which particle belongs to which rank.
+        source : the original source object
+
+        Parameters
+        ----------
+        freeze : list
+            a list of columns to already exchange
+    """
+    def __init__(self, source, domain, position='Position', freeze=[]):
+
+        self.domain = domain
+        self.source = source
+        self.position = position
+        self.layout = domain.decompose(source[position].compute())
+
+        self._size = self.layout.newlength
+
+        CatalogSource.__init__(self, comm=source.comm)
+        self.attrs.update(source.attrs)
+        self._frozen = {}
+
+        self.freeze(freeze)
+
+    def freeze(self, columns):
+        for column in columns:
+            if column not in self._frozen:
+                self._frozen[column] = self.get_hardcolumn(column)
+
+    @property
+    def hardcolumns(self):
+        return self.source.columns
+
+    def get_hardcolumn(self, col):
+        if col not in self._frozen:
+            data = self.source[col].compute()
+            return self.make_column(self.layout.exchange(data))
+        else:
+            return self.make_column(self._frozen[col])

--- a/nbodykit/base/tests/test_decomposed.py
+++ b/nbodykit/base/tests/test_decomposed.py
@@ -15,10 +15,17 @@ def test_decomposed(comm):
     Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
     source = LogNormalCatalog(Plin=Plin, nbar=1e-5, BoxSize=128., Nmesh=8, seed=42)
 
-    decomposed = source.decompose(domain=source.pm.domain, freeze=['Position'])
+    decomposed = source.decompose(domain=source.pm.domain, columns=None)
 
     assert 'Position' in decomposed
     assert 'Velocity' in decomposed
 
     assert len(decomposed['Position'].compute()) == decomposed.size
     assert len(decomposed['Velocity'].compute()) == decomposed.size
+
+    decomposed = source.decompose(domain=source.pm.domain, columns=['Position'])
+
+    assert 'Position' in decomposed
+    assert 'Velocity' not in decomposed
+
+    assert len(decomposed['Position'].compute()) == decomposed.size

--- a/nbodykit/base/tests/test_decomposed.py
+++ b/nbodykit/base/tests/test_decomposed.py
@@ -1,0 +1,24 @@
+from runtests.mpi import MPITest
+from nbodykit.base.decomposed import DecomposedCatalog
+from numpy.testing import assert_allclose, assert_array_equal
+from nbodykit import setup_logging
+import pytest
+from nbodykit.lab import *
+
+setup_logging("debug")
+
+@MPITest([1, 4])
+def test_decomposed(comm):
+    cosmo = cosmology.Planck15
+    CurrentMPIComm.set(comm)
+
+    Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
+    source = LogNormalCatalog(Plin=Plin, nbar=1e-5, BoxSize=128., Nmesh=8, seed=42)
+
+    decomposed = source.decompose(domain=source.pm.domain, freeze=['Position'])
+
+    assert 'Position' in decomposed
+    assert 'Velocity' in decomposed
+
+    assert len(decomposed['Position'].compute()) == decomposed.size
+    assert len(decomposed['Velocity'].compute()) == decomposed.size

--- a/nbodykit/source/catalog/lognormal.py
+++ b/nbodykit/source/catalog/lognormal.py
@@ -88,6 +88,8 @@ class LogNormalCatalog(CatalogSource):
 
         # make the actual source
         self._source, pm = self._makesource(BoxSize=BoxSize, Nmesh=Nmesh)
+        self.pm = pm
+
         self.attrs['Nmesh'] = pm.Nmesh.copy()
         self.attrs['BoxSize'] = pm.BoxSize.copy()
 


### PR DESCRIPTION
This PR adds a decompose method that allows decomposing a catalog to a given domain decompostion policy. The current API focuses on the spatial decomposition.

