### PR TITLE
WIP: Workaround dask 0.18.1 stopped returning views in compute()

### DIFF
--- a/nbodykit/__init__.py
+++ b/nbodykit/__init__.py
@@ -2,9 +2,15 @@ from .version import __version__
 
 from mpi4py import MPI
 
-# prevents too many threads exception when using MPI and dask
 import dask
-dask.set_options(get=dask.get)
+
+try:
+    # prevents too many threads exception when using MPI and dask
+    # by disabling threading in dask.
+    dask.config.set(scheduler='synchronous') 
+except:
+    # deprecated since 0.18.1
+    dask.set_options(get=dask.get)
 
 _global_options = {}
 _global_options['global_cache_size'] = 1e8 # 100 MB

--- a/nbodykit/algorithms/pair_counters/domain.py
+++ b/nbodykit/algorithms/pair_counters/domain.py
@@ -204,6 +204,7 @@ def decompose_survey_data(first, second, attrs, logger, smoothing, domain_factor
 
     # pass in comoving dist to Corrfunc instead of redshift
     if not angular:
+        pos1 = pos1.copy() # we need to overwrite it; dask doesn't always return a copy after 0.18.1
         pos1[:,2] = rdist1
 
     # set up position for second too
@@ -219,6 +220,7 @@ def decompose_survey_data(first, second, attrs, logger, smoothing, domain_factor
 
         # pass in comoving distance instead of redshift
         if not angular:
+            pos2 = pos2.copy() # we need to overwrite it; dask doesn't always return a copy after 0.18.1
             pos2[:,2] = rdist2
     else:
         pos2 = pos1


### PR DESCRIPTION
Due to https://github.com/dask/dask/issues/3674 tests in Corrfunc based pair counters are failing due to the assignment operator upon the return value of dask. 
