### PR TITLE
Ignore divide errors.

### DIFF
--- a/nbodykit/algorithms/fftpower.py
+++ b/nbodykit/algorithms/fftpower.py
@@ -482,7 +482,7 @@ class ProjectedFFTPower(FFTBase):
         self.power = numpy.empty(len(kedges) - 1,
                 dtype=[('k', 'f8'), ('power', 'c16'), ('modes', 'f8')])
 
-        with numpy.errstate(invalid='ignore'):
+        with numpy.errstate(invalid='ignore', divide='ignore'):
             self.power['k'] = (xsum / Nsum)[1:-1]
             self.power['power'] = (Psum / Nsum)[1:-1] * boxsize.prod() # dimension is 'volume'
             self.power['modes'] = Nsum[1:-1]
@@ -678,7 +678,7 @@ def project_to_basis(y3d, edges, los=[0, 0, 1], poles=[]):
 
     # reshape and slice to remove out of bounds points
     sl = slice(1, -1)
-    with numpy.errstate(invalid='ignore'):
+    with numpy.errstate(invalid='ignore', divide='ignore'):
 
         # 2D binned results
         y2d       = (ysum[0,...] / Nsum)[sl,sl] # ell=0 is first index

--- a/nbodykit/meshtools.py
+++ b/nbodykit/meshtools.py
@@ -132,7 +132,7 @@ class MeshSlab(object):
         array_like, (slab.shape)
             the `mu` value at each point in the slab
         """
-        with numpy.errstate(invalid='ignore'):
+        with numpy.errstate(invalid='ignore', divide='ignore'):
             return sum(self.coords(i) * los[i] for i in range(self.ndim)) / self.norm2()**0.5
 
     @property

--- a/nbodykit/mockmaker.py
+++ b/nbodykit/mockmaker.py
@@ -129,7 +129,7 @@ def gaussian_complex_fields(pm, linear_power, seed,
         if compute_displacement:
 
             # ignore division where k==0 and set to 0
-            with numpy.errstate(invalid='ignore'):
+            with numpy.errstate(invalid='ignore', divide='ignore'):
                 for i in range(delta_k.ndim):
                     disp_slab = islabs[2+i]
                     disp_slab[...] *= kslab[i] / k2 * delta_slab[...]


### PR DESCRIPTION
In numpy 1.15 divide by zero is separate from invalid errors. This PR silences them so we don't get too many warning messages.