### PR TITLE
Rework CurrentMPIComm

### DIFF
--- a/nbodykit/algorithms/pair_counters/tests/test_2d.py
+++ b/nbodykit/algorithms/pair_counters/tests/test_2d.py
@@ -11,12 +11,12 @@ setup_logging()
 def gather_data(source, name):
     return numpy.concatenate(source.comm.allgather(source[name].compute()), axis=0)
 
-def generate_sim_data(seed):
-    return UniformCatalog(nbar=3e-6, BoxSize=512., seed=seed)
+def generate_sim_data(seed, comm):
+    return UniformCatalog(nbar=3e-6, BoxSize=512., seed=seed, comm=comm)
 
-def generate_survey_data(seed):
+def generate_survey_data(seed, comm):
     cosmo = cosmology.Planck15
-    s = RandomCatalog(1000, seed=seed)
+    s = RandomCatalog(1000, seed=seed, comm=comm)
 
     # ra, dec, z
     s['Redshift'] = s.rng.normal(loc=0.5, scale=0.1)
@@ -57,10 +57,9 @@ def reference_survey_paircount(pos1, w1, redges, Nmu, pos2=None, w2=None, los=2)
 
 @MPITest([1, 3])
 def test_sim_periodic_auto(comm):
-    CurrentMPIComm.set(comm)
 
     # uniform source of particles
-    source = generate_sim_data(seed=42)
+    source = generate_sim_data(seed=42, comm=comm)
 
     # add some weights b/w 0 and 1
     source['Weight'] = source.rng.uniform()
@@ -83,10 +82,9 @@ def test_sim_periodic_auto(comm):
 
 @MPITest([3])
 def test_sim_diff_los(comm):
-    CurrentMPIComm.set(comm)
 
     # uniform source of particles
-    source = generate_sim_data(seed=42)
+    source = generate_sim_data(seed=42, comm=comm)
 
     # add some weights b/w 0 and 1
     source['Weight'] = source.rng.uniform()
@@ -109,10 +107,9 @@ def test_sim_diff_los(comm):
 
 @MPITest([1, 3])
 def test_sim_nonperiodic_auto(comm):
-    CurrentMPIComm.set(comm)
 
     # uniform source of particles
-    source = generate_sim_data(seed=42)
+    source = generate_sim_data(seed=42, comm=comm)
     source['Weight'] = numpy.random.random(size=len(source))
 
     # make the bin edges
@@ -134,11 +131,10 @@ def test_sim_nonperiodic_auto(comm):
 
 @MPITest([1, 3])
 def test_sim_periodic_cross(comm):
-    CurrentMPIComm.set(comm)
 
     # generate data
-    first = generate_sim_data(seed=42)
-    second = generate_sim_data(seed=84)
+    first = generate_sim_data(seed=42, comm=comm)
+    second = generate_sim_data(seed=84, comm=comm)
 
     # make the bin edges
     redges = numpy.linspace(10, 40., 10)
@@ -159,10 +155,9 @@ def test_sim_periodic_cross(comm):
 @MPITest([1, 4])
 def test_survey_auto(comm):
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # random particles
-    source = generate_survey_data(seed=42)
+    source = generate_survey_data(seed=42, comm=comm)
     source['Weight'] = source.rng.uniform()
 
     # make the bin edges
@@ -185,12 +180,11 @@ def test_survey_auto(comm):
 @MPITest([1, 4])
 def test_survey_cross(comm):
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # random particles
-    first = generate_survey_data(seed=42)
+    first = generate_survey_data(seed=42, comm=comm)
     first['Weight'] = first.rng.uniform()
-    second = generate_survey_data(seed=84)
+    second = generate_survey_data(seed=84, comm=comm)
     second['Weight'] = second.rng.uniform()
 
     # make the bin edges
@@ -220,10 +214,9 @@ def test_survey_cross(comm):
 
 @MPITest([1])
 def test_missing_Nmu(comm):
-    CurrentMPIComm.set(comm)
 
     # generate data
-    source = generate_sim_data(seed=42)
+    source = generate_sim_data(seed=42, comm=comm)
     redges = numpy.linspace(10, 150, 10)
 
     # missing Nmu

--- a/nbodykit/algorithms/pair_counters/tests/test_angular.py
+++ b/nbodykit/algorithms/pair_counters/tests/test_angular.py
@@ -14,14 +14,14 @@ setup_logging()
 def gather_data(source, name):
     return numpy.concatenate(source.comm.allgather(source[name].compute()), axis=0)
 
-def generate_survey_data(seed):
-    s = RandomCatalog(1000, seed=seed)
+def generate_survey_data(seed, comm):
+    s = RandomCatalog(1000, seed=seed, comm=comm)
     s['RA'] = s.rng.uniform(low=50, high=260)
     s['DEC'] = s.rng.uniform(low=-10.6, high=60.)
     return s
 
-def generate_sim_data(seed):
-    s = UniformCatalog(nbar=1000, BoxSize=1.0, seed=seed)
+def generate_sim_data(seed, comm):
+    s = UniformCatalog(nbar=1000, BoxSize=1.0, seed=seed, comm=comm)
     s['RA'], s['DEC'] = transform.CartesianToEquatorial(s['Position'], observer=0.5*s.attrs['BoxSize'])
     return s
 
@@ -42,10 +42,9 @@ def reference_paircount(pos1, w1, edges, pos2=None, w2=None):
 
 @MPITest([1, 4])
 def test_survey_auto(comm):
-    CurrentMPIComm.set(comm)
 
     # random particles
-    source = generate_survey_data(seed=42)
+    source = generate_survey_data(seed=42, comm=comm)
 
     # add some weights b/w 0 and 1
     source['Weight'] = source.rng.uniform()
@@ -71,12 +70,11 @@ def test_survey_auto(comm):
 
 @MPITest([1, 4])
 def test_survey_cross(comm):
-    CurrentMPIComm.set(comm)
 
     # random particles with weights
-    first = generate_survey_data(seed=42)
+    first = generate_survey_data(seed=42, comm=comm)
     first['Weight'] = first.rng.uniform()
-    second = generate_survey_data(seed=84)
+    second = generate_survey_data(seed=84, comm=comm)
     second['Weight'] = second.rng.uniform()
 
     # make the bin edges
@@ -107,10 +105,9 @@ def test_survey_cross(comm):
 
 @MPITest([1, 4])
 def test_sim_auto(comm):
-    CurrentMPIComm.set(comm)
 
     # random particles
-    source = generate_sim_data(seed=42)
+    source = generate_sim_data(seed=42, comm=comm)
 
     # add some weights b/w 0 and 1
     source['Weight'] = source.rng.uniform()
@@ -136,12 +133,11 @@ def test_sim_auto(comm):
 
 @MPITest([1, 4])
 def test_sim_cross(comm):
-    CurrentMPIComm.set(comm)
 
     # random particles with weights
-    first = generate_sim_data(seed=42)
+    first = generate_sim_data(seed=42, comm=comm)
     first['Weight'] = first.rng.uniform()
-    second = generate_sim_data(seed=84)
+    second = generate_sim_data(seed=84, comm=comm)
     second['Weight'] = second.rng.uniform()
 
     # make the bin edges
@@ -171,8 +167,7 @@ def test_sim_cross(comm):
 @MPITest([1])
 def test_missing_columns(comm):
 
-    CurrentMPIComm.set(comm)
-    source = generate_survey_data(seed=42)
+    source = generate_survey_data(seed=42, comm=comm)
     edges = numpy.linspace(0.01, 10.0, 10)
 
     # missing column

--- a/nbodykit/algorithms/pair_counters/tests/test_projected.py
+++ b/nbodykit/algorithms/pair_counters/tests/test_projected.py
@@ -10,12 +10,12 @@ setup_logging()
 def gather_data(source, name):
     return numpy.concatenate(source.comm.allgather(source[name].compute()), axis=0)
 
-def generate_sim_data(seed):
-    return UniformCatalog(nbar=3e-6, BoxSize=512., seed=seed)
+def generate_sim_data(seed, comm):
+    return UniformCatalog(nbar=3e-6, BoxSize=512., seed=seed, comm=comm)
 
-def generate_survey_data(seed):
+def generate_survey_data(seed, comm):
     cosmo = cosmology.Planck15
-    s = RandomCatalog(1000, seed=seed)
+    s = RandomCatalog(1000, seed=seed, comm=comm)
 
     # ra, dec, z
     s['Redshift'] = s.rng.normal(loc=0.5, scale=0.1)
@@ -106,10 +106,9 @@ def reference_survey_paircount(pos1, w1, rp_bins, pimax, pos2=None, w2=None, los
 
 @MPITest([1, 3])
 def test_sim_periodic_auto(comm):
-    CurrentMPIComm.set(comm)
 
     # uniform source of particles
-    source = generate_sim_data(seed=42)
+    source = generate_sim_data(seed=42, comm=comm)
 
     # add some weights b/w 0 and 1
     source['Weight'] = source.rng.uniform()
@@ -129,10 +128,9 @@ def test_sim_periodic_auto(comm):
 
 @MPITest([4])
 def test_sim_diff_los(comm):
-    CurrentMPIComm.set(comm)
 
     # uniform source of particles
-    source = generate_sim_data(seed=42)
+    source = generate_sim_data(seed=42, comm=comm)
 
     # add some weights b/w 0 and 1
     source['Weight'] = source.rng.uniform()
@@ -151,10 +149,9 @@ def test_sim_diff_los(comm):
 
 @MPITest([1, 3])
 def test_sim_nonperiodic_auto(comm):
-    CurrentMPIComm.set(comm)
 
     # uniform source of particles
-    source = generate_sim_data(seed=42)
+    source = generate_sim_data(seed=42, comm=comm)
     source['Weight'] = numpy.random.random(size=len(source))
 
     # make the bin edges
@@ -172,11 +169,10 @@ def test_sim_nonperiodic_auto(comm):
 
 @MPITest([1, 3])
 def test_sim_periodic_cross(comm):
-    CurrentMPIComm.set(comm)
 
     # generate data
-    first = generate_sim_data(seed=42)
-    second = generate_sim_data(seed=84)
+    first = generate_sim_data(seed=42, comm=comm)
+    second = generate_sim_data(seed=84, comm=comm)
 
     # make the bin edges
     redges = numpy.linspace(10, 40., 10)
@@ -195,10 +191,9 @@ def test_sim_periodic_cross(comm):
 @MPITest([1, 4])
 def test_survey_auto(comm):
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # random particles
-    source = generate_survey_data(seed=42)
+    source = generate_survey_data(seed=42, comm=comm)
     source['Weight'] = source.rng.uniform()
 
     # make the bin edges
@@ -220,12 +215,11 @@ def test_survey_auto(comm):
 @MPITest([1, 4])
 def test_survey_cross(comm):
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # random particles
-    first = generate_survey_data(seed=42)
+    first = generate_survey_data(seed=42, comm=comm)
     first['Weight'] = first.rng.uniform()
-    second = generate_survey_data(seed=84)
+    second = generate_survey_data(seed=84, comm=comm)
     second['Weight'] = second.rng.uniform()
 
     # make the bin edges
@@ -255,10 +249,9 @@ def test_survey_cross(comm):
 
 @MPITest([1])
 def test_missing_pimax(comm):
-    CurrentMPIComm.set(comm)
 
     # generate data
-    source = generate_sim_data(seed=42)
+    source = generate_sim_data(seed=42, comm=comm)
     redges = numpy.linspace(10, 150, 10)
 
     # missing pimax
@@ -271,10 +264,9 @@ def test_missing_pimax(comm):
 
 @MPITest([1])
 def test_bad_pimax(comm):
-    CurrentMPIComm.set(comm)
 
     # generate data
-    source = generate_sim_data(seed=42)
+    source = generate_sim_data(seed=42, comm=comm)
 
     # pimax must be at least 1
     with pytest.raises(ValueError):

--- a/nbodykit/algorithms/paircount_tpcf/tests/test_1d.py
+++ b/nbodykit/algorithms/paircount_tpcf/tests/test_1d.py
@@ -19,18 +19,18 @@ def make_corrfunc_input(data, cosmo):
 def gather_data(source, name):
     return numpy.concatenate(source.comm.allgather(source[name].compute()), axis=0)
 
-def generate_sim_data(seed):
-    return UniformCatalog(nbar=3e-4, BoxSize=512., seed=seed)
+def generate_sim_data(seed, comm):
+    return UniformCatalog(nbar=3e-4, BoxSize=512., seed=seed, comm=comm)
 
-def generate_survey_data(seed):
+def generate_survey_data(seed, comm):
 
     # make the data
     cosmo = cosmology.Planck15
-    d = UniformCatalog(nbar=3e-4, BoxSize=512., seed=seed)
+    d = UniformCatalog(nbar=3e-4, BoxSize=512., seed=seed, comm=comm)
     d['RA'], d['DEC'], d['Redshift'] = transform.CartesianToSky(d['Position'], cosmo)
 
     # make the randoms (ensure nbar is high enough to not have missing values)
-    r = UniformCatalog(nbar=3e-4, BoxSize=512., seed=seed*2)
+    r = UniformCatalog(nbar=3e-4, BoxSize=512., seed=seed*2, comm=comm)
     r['RA'], r['DEC'], r['Redshift'] = transform.CartesianToSky(r['Position'], cosmo)
 
     return d, r
@@ -85,10 +85,9 @@ def reference_survey_tpcf(data1, randoms1, redges, data2=None, randoms2=None):
 
 @MPITest([4])
 def test_sim_periodic_auto(comm):
-    CurrentMPIComm.set(comm)
 
     # uniform source of particles
-    source = generate_sim_data(seed=42)
+    source = generate_sim_data(seed=42, comm=comm)
 
     # make the bin edges
     redges = numpy.linspace(0.01, 20, 10)
@@ -104,11 +103,10 @@ def test_sim_periodic_auto(comm):
 
 @MPITest([4])
 def test_sim_nonperiodic_auto(comm):
-    CurrentMPIComm.set(comm)
 
     # uniform source of particles
-    source = generate_sim_data(seed=42)
-    randoms = generate_sim_data(seed=84)
+    source = generate_sim_data(seed=42, comm=comm)
+    randoms = generate_sim_data(seed=84, comm=comm)
 
     # make the bin edges
     redges = numpy.linspace(0.01, 20, 10)
@@ -131,11 +129,10 @@ def test_sim_nonperiodic_auto(comm):
 
 @MPITest([4])
 def test_sim_periodic_cross(comm):
-    CurrentMPIComm.set(comm)
 
     # uniform source of particles
-    data1 = generate_sim_data(seed=42)
-    data2 = generate_sim_data(seed=84)
+    data1 = generate_sim_data(seed=42, comm=comm)
+    data2 = generate_sim_data(seed=84, comm=comm)
 
     # make the bin edges
     redges = numpy.linspace(0.01, 20, 10)
@@ -152,10 +149,9 @@ def test_sim_periodic_cross(comm):
 @MPITest([4])
 def test_survey_auto(comm):
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # data and randoms
-    data, randoms = generate_survey_data(seed=42)
+    data, randoms = generate_survey_data(seed=42, comm=comm)
 
     # make the bin edges
     redges = numpy.linspace(1.0, 10, 5)
@@ -184,11 +180,10 @@ def test_survey_auto(comm):
 @MPITest([4])
 def test_survey_cross(comm):
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # data and randoms
-    data1, randoms1 = generate_survey_data(seed=42)
-    data2, randoms2 = generate_survey_data(seed=84)
+    data1, randoms1 = generate_survey_data(seed=42, comm=comm)
+    data2, randoms2 = generate_survey_data(seed=84, comm=comm)
 
     # make the bin edges
     redges = numpy.linspace(0.01, 10.0, 5)
@@ -219,11 +214,10 @@ def test_survey_cross(comm):
 
 @MPITest([1])
 def test_low_nbar_randoms(comm):
-    CurrentMPIComm.set(comm)
 
     # uniform source of particles
-    source = generate_sim_data(seed=42)
-    randoms = UniformCatalog(nbar=3e-6, BoxSize=512., seed=84)
+    source = generate_sim_data(seed=42, comm=comm)
+    randoms = UniformCatalog(nbar=3e-6, BoxSize=512., seed=84, comm=comm)
 
     # make the bin edges
     redges = numpy.linspace(0.01, 5.0, 2)

--- a/nbodykit/algorithms/paircount_tpcf/tests/test_2d.py
+++ b/nbodykit/algorithms/paircount_tpcf/tests/test_2d.py
@@ -19,18 +19,18 @@ def make_corrfunc_input(data, cosmo):
 def gather_data(source, name):
     return numpy.concatenate(source.comm.allgather(source[name].compute()), axis=0)
 
-def generate_sim_data(seed):
-    return UniformCatalog(nbar=3e-4, BoxSize=512., seed=seed)
+def generate_sim_data(seed, comm):
+    return UniformCatalog(nbar=3e-4, BoxSize=512., seed=seed, comm=comm)
 
-def generate_survey_data(seed):
+def generate_survey_data(seed, comm):
 
     # make the data
     cosmo = cosmology.Planck15
-    d = UniformCatalog(nbar=3e-4, BoxSize=512., seed=seed)
+    d = UniformCatalog(nbar=3e-4, BoxSize=512., seed=seed, comm=comm)
     d['RA'], d['DEC'], d['Redshift'] = transform.CartesianToSky(d['Position'], cosmo)
 
     # make the randoms (ensure nbar is high enough to not have missing values)
-    r = UniformCatalog(nbar=3e-4, BoxSize=512., seed=seed*2)
+    r = UniformCatalog(nbar=3e-4, BoxSize=512., seed=seed*2, comm=comm)
     r['RA'], r['DEC'], r['Redshift'] = transform.CartesianToSky(r['Position'], cosmo)
 
     return d, r
@@ -89,10 +89,9 @@ def reference_survey_tpcf(data1, randoms1, redges, Nmu, data2=None, randoms2=Non
 
 @MPITest([3])
 def test_sim_periodic_auto(comm):
-    CurrentMPIComm.set(comm)
 
     # uniform source of particles
-    source = generate_sim_data(seed=42)
+    source = generate_sim_data(seed=42, comm=comm)
 
     # make the bin edges
     redges = numpy.linspace(0.01, 20, 10)
@@ -108,11 +107,10 @@ def test_sim_periodic_auto(comm):
 
 @MPITest([3])
 def test_sim_nonperiodic_auto(comm):
-    CurrentMPIComm.set(comm)
 
     # uniform source of particles
-    source = generate_sim_data(seed=42)
-    randoms = generate_sim_data(seed=84)
+    source = generate_sim_data(seed=42, comm=comm)
+    randoms = generate_sim_data(seed=84, comm=comm)
 
     # make the bin edges
     redges = numpy.linspace(0.01, 20, 10)
@@ -129,11 +127,10 @@ def test_sim_nonperiodic_auto(comm):
 
 @MPITest([3])
 def test_sim_periodic_cross(comm):
-    CurrentMPIComm.set(comm)
 
     # uniform source of particles
-    data1 = generate_sim_data(seed=42)
-    data2 = generate_sim_data(seed=84)
+    data1 = generate_sim_data(seed=42, comm=comm)
+    data2 = generate_sim_data(seed=84, comm=comm)
 
     # make the bin edges
     redges = numpy.linspace(0.01, 20, 10)
@@ -151,11 +148,10 @@ def test_sim_periodic_cross(comm):
 @MPITest([4])
 def test_survey_cross(comm):
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # data and randoms
-    data1, randoms1 = generate_survey_data(seed=42)
-    data2, randoms2 = generate_survey_data(seed=84)
+    data1, randoms1 = generate_survey_data(seed=42, comm=comm)
+    data2, randoms2 = generate_survey_data(seed=84, comm=comm)
 
     # make the bin edges
     redges = numpy.linspace(0.01, 10, 5)
@@ -183,11 +179,10 @@ def test_survey_cross(comm):
 @MPITest([4])
 def test_xil(comm):
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # data and randoms
-    data1, randoms1 = generate_survey_data(seed=42)
-    data2, randoms2 = generate_survey_data(seed=84)
+    data1, randoms1 = generate_survey_data(seed=42, comm=comm)
+    data2, randoms2 = generate_survey_data(seed=84, comm=comm)
 
     # make the bin edges
     redges = numpy.linspace(0.01, 10, 5)

--- a/nbodykit/algorithms/paircount_tpcf/tests/test_angular.py
+++ b/nbodykit/algorithms/paircount_tpcf/tests/test_angular.py
@@ -20,8 +20,8 @@ def get_spherical_volume(source):
 def gather_data(source, name):
     return numpy.concatenate(source.comm.allgather(source[name].compute()), axis=0)
 
-def generate_sim_data(seed):
-    s = UniformCatalog(nbar=1000, BoxSize=1.0, seed=seed)
+def generate_sim_data(seed, comm):
+    s = UniformCatalog(nbar=1000, BoxSize=1.0, seed=seed, comm=comm)
     s['RA'], s['DEC'] = transform.CartesianToEquatorial(s['Position'], observer=0.5*s.attrs['BoxSize'])
     return s
 
@@ -36,11 +36,10 @@ def reference_sim_tpcf(pos1, theta_edges, randoms=None, pos2=None):
 
 @MPITest([1, 4])
 def test_sim_nonperiodic_auto(comm):
-    CurrentMPIComm.set(comm)
 
     # uniform source of particles
-    source = generate_sim_data(seed=42)
-    randoms = generate_sim_data(seed=84)
+    source = generate_sim_data(seed=42, comm=comm)
+    randoms = generate_sim_data(seed=84, comm=comm)
 
     # make the bin edges
     theta_edges = numpy.linspace(0.1, 10.0, 20)
@@ -60,11 +59,10 @@ def test_sim_nonperiodic_auto(comm):
 
 @MPITest([1, 4])
 def test_sim_periodic_cross(comm):
-    CurrentMPIComm.set(comm)
 
     # uniform source of particles
-    data1 = generate_sim_data(seed=42)
-    data2 = generate_sim_data(seed=84)
+    data1 = generate_sim_data(seed=42, comm=comm)
+    data2 = generate_sim_data(seed=84, comm=comm)
 
     # make the bin edges
     theta_edges = numpy.linspace(0.1, 10.0, 20)
@@ -80,11 +78,10 @@ def test_sim_periodic_cross(comm):
 
 @MPITest([1, 4])
 def test_survey_auto(comm):
-    CurrentMPIComm.set(comm)
 
     # uniform source of particles
-    data = generate_sim_data(seed=42)
-    randoms = generate_sim_data(seed=84)
+    data = generate_sim_data(seed=42, comm=comm)
+    randoms = generate_sim_data(seed=84, comm=comm)
 
     # make the bin edges
     theta_edges = numpy.linspace(0.1, 10.0, 20)

--- a/nbodykit/algorithms/tests/test_cgm.py
+++ b/nbodykit/algorithms/tests/test_cgm.py
@@ -10,9 +10,7 @@ setup_logging("debug")
 @MPITest([4])
 def test_bad_input(comm):
 
-    CurrentMPIComm.set(comm)
-
-    source = UniformCatalog(3e-4, BoxSize=256, seed=42)
+    source = UniformCatalog(3e-4, BoxSize=256, seed=42, comm=comm)
     source['gal_type'] = 1
 
     # cannot rank by missing column
@@ -41,9 +39,7 @@ def test_bad_input(comm):
 @MPITest([4])
 def test_periodic_cgm(comm):
 
-    CurrentMPIComm.set(comm)
-
-    source = UniformCatalog(3e-4, BoxSize=256, seed=42)
+    source = UniformCatalog(3e-4, BoxSize=256, seed=42, comm=comm)
 
     # add mass
     logmass = source.rng.uniform(12, 15)
@@ -83,9 +79,7 @@ def test_periodic_cgm(comm):
 @MPITest([1, 4])
 def test_nonperiodic_cgm(comm):
 
-    CurrentMPIComm.set(comm)
-
-    source = UniformCatalog(3e-4, BoxSize=256, seed=42)
+    source = UniformCatalog(3e-4, BoxSize=256, seed=42, comm=comm)
 
     # add mass
     logmass = source.rng.uniform(12, 15)

--- a/nbodykit/algorithms/tests/test_conv_power.py
+++ b/nbodykit/algorithms/tests/test_conv_power.py
@@ -11,10 +11,10 @@ setup_logging("debug")
 NDATA = 1000
 NBAR = 1e-4
 
-def make_sources(cosmo):
+def make_sources(cosmo, comm):
 
-    data = RandomCatalog(NDATA, seed=42)
-    randoms = RandomCatalog(NDATA*10, seed=84)
+    data = RandomCatalog(NDATA, seed=42, comm=comm)
+    randoms = RandomCatalog(NDATA*10, seed=84, comm=comm)
 
     # add the random columns
     for s in [data, randoms]:
@@ -32,11 +32,10 @@ def make_sources(cosmo):
 @MPITest([1, 4])
 def test_diff_cross_boxsizes(comm):
 
-    CurrentMPIComm.set(comm)
     cosmo = cosmology.Planck15
 
     # make the sources
-    data, randoms = make_sources(cosmo)
+    data, randoms = make_sources(cosmo, comm)
     for s in [data, randoms]:
 
         # constant number density
@@ -63,11 +62,10 @@ def test_diff_cross_boxsizes(comm):
 @MPITest([1, 4])
 def test_true_cross_corr_fail(comm):
 
-    CurrentMPIComm.set(comm)
     cosmo = cosmology.Planck15
 
     # make the sources
-    data, randoms = make_sources(cosmo)
+    data, randoms = make_sources(cosmo, comm)
     for s in [data, randoms]:
         s['NZ'] = NBAR
 
@@ -87,11 +85,10 @@ def test_true_cross_corr_fail(comm):
 @MPITest([1, 4])
 def test_bad_cross_corr_columns(comm):
 
-    CurrentMPIComm.set(comm)
     cosmo = cosmology.Planck15
 
     # make the sources
-    data, randoms = make_sources(cosmo)
+    data, randoms = make_sources(cosmo, comm)
     for s in [data, randoms]:
         s['NZ'] = NBAR
 
@@ -110,11 +107,10 @@ def test_bad_cross_corr_columns(comm):
 @MPITest([1, 4])
 def test_cross_corr(comm):
 
-    CurrentMPIComm.set(comm)
     cosmo = cosmology.Planck15
 
     # make the sources
-    data, randoms = make_sources(cosmo)
+    data, randoms = make_sources(cosmo, comm)
     for s in [data, randoms]:
 
         # constant number density
@@ -145,11 +141,10 @@ def test_cross_corr(comm):
 @MPITest([1, 4])
 def test_bad_input(comm):
 
-    CurrentMPIComm.set(comm)
     cosmo = cosmology.Planck15
 
     # source has wrong type
-    data, randoms = make_sources(cosmo)
+    data, randoms = make_sources(cosmo, comm)
     for s in [data, randoms]:
         s['NZ'] = NBAR
         s['FKPWeight'] = 1.0 / (1 + 2e4*s['NZ'])
@@ -172,11 +167,10 @@ def test_bad_input(comm):
 @MPITest([4])
 def test_no_monopole(comm):
 
-    CurrentMPIComm.set(comm)
     cosmo = cosmology.Planck15
 
     # make the sources
-    data, randoms = make_sources(cosmo)
+    data, randoms = make_sources(cosmo, comm)
 
     # select in given redshift range
     for s in [data, randoms]:
@@ -196,11 +190,10 @@ def test_no_monopole(comm):
 @MPITest([4])
 def test_bad_normalization(comm):
 
-    CurrentMPIComm.set(comm)
     cosmo = cosmology.Planck15
 
     # make the sources
-    data, randoms = make_sources(cosmo)
+    data, randoms = make_sources(cosmo, comm)
 
     # select in given redshift range
     for s in [data, randoms]:
@@ -220,11 +213,10 @@ def test_bad_normalization(comm):
 @MPITest([4])
 def test_selection(comm):
 
-    CurrentMPIComm.set(comm)
     cosmo = cosmology.Planck15
 
     # make the sources
-    data, randoms = make_sources(cosmo)
+    data, randoms = make_sources(cosmo, comm)
 
     # select in given redshift range
     for s in [data, randoms]:
@@ -256,11 +248,10 @@ def test_selection(comm):
 @MPITest([1, 4])
 def test_run(comm):
 
-    CurrentMPIComm.set(comm)
     cosmo = cosmology.Planck15
 
     # make the sources
-    data, randoms = make_sources(cosmo)
+    data, randoms = make_sources(cosmo, comm)
     for s in [data, randoms]:
 
         # constant number density
@@ -299,11 +290,10 @@ def test_with_zhist(comm):
     NBAR = 1e-4
     FSKY = 0.15
 
-    CurrentMPIComm.set(comm)
     cosmo = cosmology.Planck15
 
     # make the sources
-    data, randoms = make_sources(cosmo)
+    data, randoms = make_sources(cosmo, comm)
 
     # initialize the FKP source
     fkp = FKPCatalog(data, randoms)

--- a/nbodykit/algorithms/tests/test_fftcorr.py
+++ b/nbodykit/algorithms/tests/test_fftcorr.py
@@ -10,8 +10,7 @@ setup_logging("debug")
 @MPITest([1])
 def test_fftcorr_poles(comm):
 
-    CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=3e-3, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=3e-3, BoxSize=512., seed=42, comm=comm)
 
     r = FFTCorr(source, mode='2d', BoxSize=1024, Nmesh=32, poles=[0,2,4])
     pkmu = r.corr['corr'].real
@@ -26,8 +25,7 @@ def test_fftcorr_poles(comm):
 @MPITest([1])
 def test_fftcorr_unique(comm):
 
-    CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
 
     r = FFTCorr(source, mode='1d', Nmesh=32, dr=0)
     p = r.corr
@@ -36,8 +34,7 @@ def test_fftcorr_unique(comm):
 @MPITest([1])
 def test_fftcorr_padding(comm):
 
-    CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
 
     r = FFTCorr(source, mode='1d', BoxSize=1024, Nmesh=32)
     assert r.attrs['N1'] != 0
@@ -46,8 +43,7 @@ def test_fftcorr_padding(comm):
 @MPITest([1])
 def test_fftcorr_save(comm):
 
-    CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
 
     r = FFTCorr(source, mode='2d', Nmesh=32)
     r.save('fftcorr-test.json')
@@ -64,11 +60,10 @@ def test_fftcorr_save(comm):
 def test_fftcorr_mismatch_boxsize(comm):
 
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # input sources
-    source1 = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42)
-    source2 = UniformCatalog(nbar=3e-4, BoxSize=1024., seed=42)
+    source1 = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
+    source2 = UniformCatalog(nbar=3e-4, BoxSize=1024., seed=42, comm=comm)
 
     r = FFTCorr(source1, second=source2, mode='1d', BoxSize=1024, Nmesh=32)
 
@@ -76,11 +71,10 @@ def test_fftcorr_mismatch_boxsize(comm):
 def test_fftcorr_mismatch_boxsize_fail(comm):
 
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # input sources
-    mesh1 = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42).to_mesh(Nmesh=32)
-    mesh2 = UniformCatalog(nbar=3e-4, BoxSize=1024., seed=42).to_mesh(Nmesh=32)
+    mesh1 = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm).to_mesh(Nmesh=32)
+    mesh2 = UniformCatalog(nbar=3e-4, BoxSize=1024., seed=42, comm=comm).to_mesh(Nmesh=32)
 
     # raises an exception b/c meshes have different box sizes
     with pytest.raises(ValueError):

--- a/nbodykit/algorithms/tests/test_fftpower.py
+++ b/nbodykit/algorithms/tests/test_fftpower.py
@@ -10,8 +10,7 @@ setup_logging("debug")
 @MPITest([4])
 def test_tsc_aliasing(comm):
 
-    CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
     mesh = source.to_mesh(window='tsc', Nmesh=64, compensated=True)
 
     # compute the power spectrum -- should be flat shot noise
@@ -28,8 +27,7 @@ def test_tsc_aliasing(comm):
 @MPITest([4])
 def test_cic_aliasing(comm):
 
-    CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
     mesh = source.to_mesh(window='cic', Nmesh=64, compensated=True)
 
     # compute the power spectrum -- should be flat shot noise
@@ -47,8 +45,7 @@ def test_cic_aliasing(comm):
 @MPITest([1])
 def test_fftpower_poles(comm):
 
-    CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=3e-3, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=3e-3, BoxSize=512., seed=42, comm=comm)
 
     r = FFTPower(source, mode='2d', BoxSize=1024, Nmesh=32, poles=[0,2,4])
     pkmu = r.power['power'].real
@@ -63,8 +60,7 @@ def test_fftpower_poles(comm):
 @MPITest([1])
 def test_fftpower_unique(comm):
 
-    CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
 
     r = FFTPower(source, mode='1d', Nmesh=32, dk=0)
     p = r.power
@@ -73,8 +69,7 @@ def test_fftpower_unique(comm):
 @MPITest([1])
 def test_fftpower_padding(comm):
 
-    CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
 
     r = FFTPower(source, mode='1d', BoxSize=1024, Nmesh=32)
     assert r.attrs['N1'] != 0
@@ -83,8 +78,7 @@ def test_fftpower_padding(comm):
 @MPITest([1])
 def test_fftpower_save(comm):
 
-    CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
 
     r = FFTPower(source, mode='2d', Nmesh=32)
     r.save('fftpower-test.json')
@@ -99,8 +93,7 @@ def test_fftpower_save(comm):
 @MPITest([1])
 def test_fftpower(comm):
 
-    CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
 
     r = FFTPower(source, mode='1d', Nmesh=32)
     # the zero mode is cleared
@@ -110,11 +103,10 @@ def test_fftpower(comm):
 def test_fftpower_mismatch_boxsize(comm):
 
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # input sources
-    source1 = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42)
-    source2 = UniformCatalog(nbar=3e-4, BoxSize=1024., seed=42)
+    source1 = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
+    source2 = UniformCatalog(nbar=3e-4, BoxSize=1024., seed=42, comm=comm)
 
     r = FFTPower(source1, second=source2, mode='1d', BoxSize=1024, Nmesh=32)
 
@@ -122,11 +114,10 @@ def test_fftpower_mismatch_boxsize(comm):
 def test_fftpower_mismatch_boxsize_fail(comm):
 
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # input sources
-    mesh1 = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42).to_mesh(Nmesh=32)
-    mesh2 = UniformCatalog(nbar=3e-4, BoxSize=1024., seed=42).to_mesh(Nmesh=32)
+    mesh1 = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm).to_mesh(Nmesh=32)
+    mesh2 = UniformCatalog(nbar=3e-4, BoxSize=1024., seed=42, comm=comm).to_mesh(Nmesh=32)
 
     # raises an exception b/c meshes have different box sizes
     with pytest.raises(ValueError):
@@ -135,8 +126,7 @@ def test_fftpower_mismatch_boxsize_fail(comm):
 @MPITest([1])
 def test_projectedpower(comm):
 
-    CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
 
     Nmesh = 64
     rp1 = ProjectedFFTPower(source, Nmesh=Nmesh, axes=[1])

--- a/nbodykit/algorithms/tests/test_fftrecon.py
+++ b/nbodykit/algorithms/tests/test_fftrecon.py
@@ -12,12 +12,11 @@ def test_fftrecon(comm):
     cosmo = cosmology.Planck15
     # this should generate 15 particles
     Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
-    CurrentMPIComm.set(comm)
 
     # very high bias to increase the accuracy of reconstruction;
     # since shotnoise is high.
-    data = LogNormalCatalog(Plin=Plin, bias=4, nbar=1e-4, BoxSize=1024., Nmesh=64, seed=42)
-    ran = UniformCatalog(nbar=1e-4, BoxSize=1024., seed=42)
+    data = LogNormalCatalog(Plin=Plin, bias=4, nbar=1e-4, BoxSize=1024., Nmesh=64, seed=42, comm=comm)
+    ran = UniformCatalog(nbar=1e-4, BoxSize=1024., seed=42, comm=comm)
 
     # lognormal mocks don't have the correct small scale power for reconstruction,
     # so we heavily smooth and assert the reconstruction

--- a/nbodykit/algorithms/tests/test_fiber_colls.py
+++ b/nbodykit/algorithms/tests/test_fiber_colls.py
@@ -1,19 +1,19 @@
 from runtests.mpi import MPITest
 from nbodykit.lab import *
 from nbodykit import setup_logging
+from nbodykit.utils import ScatterArray, GatherArray
 
 # debug logging
 setup_logging("debug")
 
 @MPITest([1, 4])
 def test_fibercolls(comm):
-    
+
     from scipy.spatial.distance import pdist, squareform 
-    from nbodykit.utils import ScatterArray, GatherArray
-    
-    CurrentMPIComm.set(comm)
+
+
     N = 10000
-    
+
     # generate the initial data
     numpy.random.seed(42)
     if comm.rank == 0:
@@ -22,31 +22,30 @@ def test_fibercolls(comm):
     else:
         ra = None
         dec = None
-    
+
     ra = ScatterArray(ra, comm)
     dec = ScatterArray(dec, comm)
 
     # compute the fiber collisions
-    r = FiberCollisions(ra, dec, degrees=True, seed=42)
+    r = FiberCollisions(ra, dec, degrees=True, seed=42, comm=comm)
     rad = r._collision_radius_rad
-    
+
     #  gather collided and position to root
     idx = GatherArray(r.labels['Collided'].compute().astype(bool), comm, root=0)
     pos = GatherArray(r.source['Position'].compute(), comm, root=0)
-    
+
     # manually compute distances and check on root
     if comm.rank == 0:
         dists = squareform(pdist(pos, metric='euclidean'))
         numpy.fill_diagonal(dists, numpy.inf) # ignore self pairs
-    
+
         # no objects in clean sample (Collided==0) should be within
         # the collision radius of any other objects in the sample
         clean_dists = dists[~idx, ~idx]
         assert (clean_dists <= rad).sum() == 0, "objects in 'clean' sample within collision radius!"
-    
+
         # the collided objects must collided with at least 
         # one object in the clean sample
         ncolls_per = (dists[idx] <= rad).sum(axis=-1)
         assert (ncolls_per >= 1).all(), "objects in 'collided' sample that do not collide with any objects!"
 
-    

--- a/nbodykit/algorithms/tests/test_fof.py
+++ b/nbodykit/algorithms/tests/test_fof.py
@@ -11,11 +11,9 @@ setup_logging("debug")
 def test_fof(comm):
     cosmo = cosmology.Planck15
 
-    CurrentMPIComm.set(comm)
-
     # lognormal particles
     Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
-    source = LogNormalCatalog(Plin=Plin, nbar=3e-3, BoxSize=128., Nmesh=32, seed=42)
+    source = LogNormalCatalog(Plin=Plin, nbar=3e-3, BoxSize=128., Nmesh=32, seed=42, comm=comm)
 
     # compute P(k,mu) and multipoles
     fof = FOF(source, linking_length=0.2, nmin=20)
@@ -27,11 +25,10 @@ def test_fof(comm):
 
 @MPITest([1, 4])
 def test_fof_parallel_no_merge(comm):
-    CurrentMPIComm.set(comm)
     from pmesh.pm import ParticleMesh
     pm = ParticleMesh(BoxSize=[8, 8, 8], Nmesh=[8, 8, 8], comm=comm)
     Q = pm.generate_uniform_particle_grid()
-    cat = ArrayCatalog({'Position' : Q}, BoxSize=pm.BoxSize, Nmesh=pm.Nmesh)
+    cat = ArrayCatalog({'Position' : Q}, BoxSize=pm.BoxSize, Nmesh=pm.Nmesh, comm=comm)
 
     fof = FOF(cat, linking_length=0.9, nmin=0)
     
@@ -41,7 +38,6 @@ def test_fof_parallel_no_merge(comm):
 
 @MPITest([1, 4])
 def test_fof_parallel_merge(comm):
-    CurrentMPIComm.set(comm)
     from pmesh.pm import ParticleMesh
     pm = ParticleMesh(BoxSize=[8, 8, 8], Nmesh=[8, 8, 8], comm=comm)
     Q = pm.generate_uniform_particle_grid(shift=0)
@@ -52,7 +48,7 @@ def test_fof_parallel_merge(comm):
     Q3 = Q.copy()
     Q3[:] += 0.02
     cat = ArrayCatalog({'Position' : 
-            numpy.concatenate([Q, Q1, Q2, Q3], axis=0)}, BoxSize=pm.BoxSize, Nmesh=pm.Nmesh)
+            numpy.concatenate([Q, Q1, Q2, Q3], axis=0)}, BoxSize=pm.BoxSize, Nmesh=pm.Nmesh, comm=comm)
 
     fof = FOF(cat, linking_length=0.011 * 3 ** 0.5, nmin=0, absolute=True)
 
@@ -64,11 +60,9 @@ def test_fof_parallel_merge(comm):
 def test_fof_nonperiodic(comm):
     cosmo = cosmology.Planck15
 
-    CurrentMPIComm.set(comm)
-
     # lognormal particles
     Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
-    source = LogNormalCatalog(Plin=Plin, nbar=3e-3, BoxSize=128., Nmesh=32, seed=42)
+    source = LogNormalCatalog(Plin=Plin, nbar=3e-3, BoxSize=128., Nmesh=32, seed=42, comm=comm)
 
     source['Density'] = KDDensity(source, margin=1).density
 

--- a/nbodykit/algorithms/tests/test_kddensity.py
+++ b/nbodykit/algorithms/tests/test_kddensity.py
@@ -12,10 +12,8 @@ setup_logging("debug")
 def test_kddensity(comm):
     cosmo = cosmology.Planck15
 
-    CurrentMPIComm.set(comm)
-
     Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
-    source = LogNormalCatalog(Plin=Plin, nbar=3e-4, BoxSize=64., Nmesh=16, seed=42)
+    source = LogNormalCatalog(Plin=Plin, nbar=3e-4, BoxSize=64., Nmesh=16, seed=42, comm=comm)
 
     kdden = KDDensity(source)
     assert kdden.density.size == source.size

--- a/nbodykit/algorithms/tests/test_threeptcf.py
+++ b/nbodykit/algorithms/tests/test_threeptcf.py
@@ -21,12 +21,11 @@ def test_sim_threeptcf(comm):
 
     import tempfile
 
-    CurrentMPIComm.set(comm)
     BoxSize = 400.0
 
     # load the test data
     filename = os.path.join(data_dir, 'threeptcf_sim_data.dat')
-    cat = CSVCatalog(filename, names=['x', 'y', 'z', 'w'])
+    cat = CSVCatalog(filename, names=['x', 'y', 'z', 'w'], comm=comm)
     cat['Position'] = transform.StackColumns(cat['x'], cat['y'], cat['z'])
     cat['Position'] *= BoxSize
 
@@ -67,13 +66,12 @@ def test_survey_threeptcf(comm):
 
     import tempfile
 
-    CurrentMPIComm.set(comm)
     BoxSize = 400.0
     cosmo = cosmology.Planck15
 
     # load the test data
     filename = os.path.join(data_dir, 'threeptcf_sim_data.dat')
-    cat = CSVCatalog(filename, names=['x', 'y', 'z', 'w'])
+    cat = CSVCatalog(filename, names=['x', 'y', 'z', 'w'], comm=comm)
     cat['Position'] = transform.StackColumns(cat['x'], cat['y'], cat['z'])
     cat['Position'] *= BoxSize
 
@@ -114,12 +112,11 @@ def test_survey_threeptcf(comm):
 @MPITest([1])
 def test_sim_threeptcf_pedantic(comm):
 
-    CurrentMPIComm.set(comm)
     BoxSize = 400.0
 
     # load the test data
     filename = os.path.join(data_dir, 'threeptcf_sim_data.dat')
-    cat = CSVCatalog(filename, names=['x', 'y', 'z', 'w'])
+    cat = CSVCatalog(filename, names=['x', 'y', 'z', 'w'], comm=comm)
     cat['Position'] = transform.StackColumns(cat['x'], cat['y'], cat['z'])
     cat['Position'] *= BoxSize
 
@@ -144,12 +141,11 @@ def test_sim_threeptcf_pedantic(comm):
 @MPITest([1])
 def test_sim_threeptcf_shuffled(comm):
 
-    CurrentMPIComm.set(comm)
     BoxSize = 400.0
 
     # load the test data
     filename = os.path.join(data_dir, 'threeptcf_sim_data.dat')
-    cat = CSVCatalog(filename, names=['x', 'y', 'z', 'w'])
+    cat = CSVCatalog(filename, names=['x', 'y', 'z', 'w'], comm=comm)
     cat['Position'] = transform.StackColumns(cat['x'], cat['y'], cat['z'])
     cat['Position'] *= BoxSize
 

--- a/nbodykit/algorithms/tests/test_zhist.py
+++ b/nbodykit/algorithms/tests/test_zhist.py
@@ -12,13 +12,12 @@ def test_save(comm):
     N = 1000
     FSKY = 1.0
     
-    CurrentMPIComm.set(comm)
     cosmo = cosmology.Planck15
     
     # create the source
-    source = RandomCatalog(N, seed=42)
+    source = RandomCatalog(N, seed=42, comm=comm)
     source['z'] = source.rng.normal(loc=0.5, scale=0.1)
-    
+
     # compute the histogram
     r = RedshiftHistogram(source, FSKY, cosmo, redshift='z')
     r.run()    
@@ -39,11 +38,10 @@ def test_unweighted(comm):
     N = 1000
     FSKY = 1.0
     
-    CurrentMPIComm.set(comm)
     cosmo = cosmology.Planck15
     
     # create the source
-    source = RandomCatalog(N, seed=42)
+    source = RandomCatalog(N, seed=42, comm=comm)
     source['z'] = source.rng.normal(loc=0.5, scale=0.1)
     
     # compute the histogram
@@ -58,11 +56,10 @@ def test_weighted(comm):
     N = 1000
     FSKY = 1.0
     
-    CurrentMPIComm.set(comm)
     cosmo = cosmology.Planck15
     
     # create the source
-    source = RandomCatalog(N, seed=42)
+    source = RandomCatalog(N, seed=42, comm=comm)
     source['z'] = source.rng.normal(loc=0.5, scale=0.1)
     source['weight'] = source.rng.uniform(0, high=1.)
     

--- a/nbodykit/base/tests/test_catalog.py
+++ b/nbodykit/base/tests/test_catalog.py
@@ -10,9 +10,7 @@ setup_logging()
 
 @MPITest([1])
 def test_default_columns(comm):
-    CurrentMPIComm.set(comm)
-
-    cat = UniformCatalog(nbar=100, BoxSize=1.0)
+    cat = UniformCatalog(nbar=100, BoxSize=1.0, comm=comm)
 
     # weight column is default
     assert cat['Weight'].is_default
@@ -26,7 +24,6 @@ def test_default_columns(comm):
 def test_save(comm):
 
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     import tempfile
     import shutil
@@ -39,7 +36,7 @@ def test_save(comm):
     tmpfile = comm.bcast(tmpfile)
 
     # initialize a uniform catalog
-    source = UniformCatalog(nbar=2e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=2e-4, BoxSize=512., seed=42, comm=comm)
 
     # add a non-array attrs (saved as JSON)
     source.attrs['empty'] = None
@@ -52,7 +49,7 @@ def test_save(comm):
     assert not any(col in datasets for col in ['Value', 'Selection', 'Weight'])
 
     # load as a BigFileCatalog
-    source2 = BigFileCatalog(tmpfile, attrs={"Nmesh":32})
+    source2 = BigFileCatalog(tmpfile, attrs={"Nmesh":32}, comm=comm)
 
     # check sources
     for k in source.attrs:
@@ -70,9 +67,8 @@ def test_save(comm):
 
 @MPITest([1, 4])
 def test_tomesh(comm):
-    CurrentMPIComm.set(comm)
 
-    source = UniformCatalog(nbar=2e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=2e-4, BoxSize=512., seed=42, comm=comm)
     source['Weight0'] = source['Velocity'][:, 0]
     source['Weight1'] = source['Velocity'][:, 1]
     source['Weight2'] = source['Velocity'][:, 2]
@@ -102,8 +98,7 @@ def test_tomesh(comm):
 
 @MPITest([4])
 def test_bad_column(comm):
-    CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=2e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=2e-4, BoxSize=512., seed=42, comm=comm)
 
     # read a missing column
     with pytest.raises(ValueError):
@@ -115,9 +110,8 @@ def test_bad_column(comm):
 
 @MPITest([4])
 def test_empty_slice(comm):
-    CurrentMPIComm.set(comm)
 
-    source = UniformCatalog(nbar=2e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=2e-4, BoxSize=512., seed=42, comm=comm)
 
     # empty slice returns self
     source2 = source[source['Selection']]
@@ -135,9 +129,8 @@ def test_empty_slice(comm):
 
 @MPITest([4])
 def test_slice(comm):
-    CurrentMPIComm.set(comm)
 
-    source = UniformCatalog(nbar=2e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=2e-4, BoxSize=512., seed=42, comm=comm)
 
     # slice a subset
     subset = source[:10]
@@ -159,9 +152,8 @@ def test_slice(comm):
 
 @MPITest([4])
 def test_dask_slice(comm):
-    CurrentMPIComm.set(comm)
 
-    source = UniformCatalog(nbar=2e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=2e-4, BoxSize=512., seed=42, comm=comm)
 
     # add a selection column
     index = numpy.random.choice([True, False], size=len(source))
@@ -189,13 +181,13 @@ def test_index(comm):
 @MPITest([1 ,4])
 def test_transform(comm):
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
+
     data = numpy.ones(100, dtype=[
             ('Position', ('f4', 3)),
             ('Velocity', ('f4', 3))]
             )
 
-    source = ArrayCatalog(data, BoxSize=100, Nmesh=32)
+    source = ArrayCatalog(data, BoxSize=100, Nmesh=32, comm=comm)
 
     source['Velocity'] = source['Position'] + source['Velocity']
 
@@ -210,9 +202,8 @@ def test_transform(comm):
 
 @MPITest([1, 4])
 def test_getitem_columns(comm):
-    CurrentMPIComm.set(comm)
 
-    source = UniformCatalog(nbar=2e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=2e-4, BoxSize=512., seed=42, comm=comm)
 
     # bad column name
     with pytest.raises(KeyError):
@@ -226,8 +217,7 @@ def test_getitem_columns(comm):
 @MPITest([1, 4])
 def test_delitem(comm):
 
-    CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=2e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=2e-4, BoxSize=512., seed=42, comm=comm)
 
     # add a test column
     test = numpy.ones(source.size)

--- a/nbodykit/base/tests/test_catalog.py
+++ b/nbodykit/base/tests/test_catalog.py
@@ -245,9 +245,10 @@ def test_delitem(comm):
     del source['test']
     assert 'test' not in source
 
-def test_columnaccessor():
+@MPITest([1])
+def test_columnaccessor(comm):
     from nbodykit.base.catalog import ColumnAccessor
-    source = UniformCatalog(nbar=2e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=2e-4, BoxSize=512., seed=42, comm=comm)
 
     c = source['Position']
     truth = c[0].compute()

--- a/nbodykit/base/tests/test_catalogmesh.py
+++ b/nbodykit/base/tests/test_catalogmesh.py
@@ -11,8 +11,7 @@ setup_logging("debug")
 @MPITest([1])
 def test_tsc_interlacing(comm):
 
-    CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
 
     # interlacing with TSC
     mesh = source.to_mesh(window='tsc', Nmesh=64, interlaced=True, compensated=True)
@@ -24,8 +23,7 @@ def test_tsc_interlacing(comm):
 @MPITest([1])
 def test_paint_chunksize(comm):
 
-    CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
 
     # interlacing with TSC
     mesh = source.to_mesh(window='tsc', Nmesh=64, interlaced=True, compensated=True)
@@ -41,8 +39,7 @@ def test_paint_chunksize(comm):
 @MPITest([1])
 def test_cic_interlacing(comm):
 
-    CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
 
     # interlacing with TSC
     mesh = source.to_mesh(window='cic', Nmesh=64, interlaced=True, compensated=True)
@@ -54,8 +51,7 @@ def test_cic_interlacing(comm):
 @MPITest([1])
 def test_setters(comm):
 
-    CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
 
     # make the mesh
     mesh = source.to_mesh(window='cic', Nmesh=64, interlaced=True, compensated=True)
@@ -75,8 +71,7 @@ def test_setters(comm):
 @MPITest([1])
 def test_bad_window(comm):
 
-    CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
 
     # make the mesh
     mesh = source.to_mesh(window='cic', Nmesh=64, interlaced=True, compensated=True)
@@ -88,8 +83,7 @@ def test_bad_window(comm):
 @MPITest([1])
 def test_no_compensation(comm):
 
-    CurrentMPIComm.set(comm)
-    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
 
     # make the mesh
     mesh = source.to_mesh(window='cic', Nmesh=64, interlaced=True, compensated=True)
@@ -104,10 +98,9 @@ def test_no_compensation(comm):
 
 @MPITest([1, 4])
 def test_view(comm):
-    CurrentMPIComm.set(comm)
 
     # the CatalogSource
-    source = UniformCatalog(nbar=2e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=2e-4, BoxSize=512., seed=42, comm=comm)
     source['TEST'] = 10.
     source.attrs['TEST'] = 10.0
 
@@ -126,10 +119,9 @@ def test_view(comm):
 
 @MPITest([1, 4])
 def test_apply_nocompensation(comm):
-    CurrentMPIComm.set(comm)
 
     # the CatalogSource
-    source = UniformCatalog(nbar=2e-4, BoxSize=512, seed=42)
+    source = UniformCatalog(nbar=2e-4, BoxSize=512, seed=42, comm=comm)
     source['TEST'] = 10.
     source['Position2'] = source['Position']
     source.attrs['TEST'] = 10.0
@@ -156,10 +148,9 @@ def test_apply_nocompensation(comm):
 
 @MPITest([1])
 def test_apply_compensated(comm):
-    CurrentMPIComm.set(comm)
 
     # the CatalogSource
-    source = UniformCatalog(nbar=2e-4, BoxSize=512., seed=42)
+    source = UniformCatalog(nbar=2e-4, BoxSize=512., seed=42, comm=comm)
     source['TEST'] = 10.
     source['Position2'] = source['Position']
     source.attrs['TEST'] = 10.0

--- a/nbodykit/base/tests/test_catalogmesh.py
+++ b/nbodykit/base/tests/test_catalogmesh.py
@@ -8,7 +8,7 @@ import pytest
 # debug logging
 setup_logging("debug")
 
-@MPITest([4])
+@MPITest([1])
 def test_tsc_interlacing(comm):
 
     CurrentMPIComm.set(comm)
@@ -38,7 +38,7 @@ def test_paint_chunksize(comm):
 
     assert_allclose(r1, r2)
 
-@MPITest([4])
+@MPITest([1])
 def test_cic_interlacing(comm):
 
     CurrentMPIComm.set(comm)
@@ -51,7 +51,7 @@ def test_cic_interlacing(comm):
     # if the compensation worked
     r = FFTPower(mesh, mode='1d', kmin=0.02)
 
-@MPITest([4])
+@MPITest([1])
 def test_setters(comm):
 
     CurrentMPIComm.set(comm)
@@ -72,7 +72,7 @@ def test_setters(comm):
     mesh.window = 'tsc'
     assert mesh.window == 'tsc'
 
-@MPITest([4])
+@MPITest([1])
 def test_bad_window(comm):
 
     CurrentMPIComm.set(comm)
@@ -85,7 +85,7 @@ def test_bad_window(comm):
     with pytest.raises(Exception):
         mesh.window = "BAD"
 
-@MPITest([4])
+@MPITest([1])
 def test_no_compensation(comm):
 
     CurrentMPIComm.set(comm)
@@ -102,7 +102,7 @@ def test_no_compensation(comm):
         actions = mesh.actions
 
 
-@MPITest([4])
+@MPITest([1, 4])
 def test_view(comm):
     CurrentMPIComm.set(comm)
 

--- a/nbodykit/base/tests/test_decomposed.py
+++ b/nbodykit/base/tests/test_decomposed.py
@@ -10,10 +10,9 @@ setup_logging("debug")
 @MPITest([1, 4])
 def test_decomposed(comm):
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
-    source = LogNormalCatalog(Plin=Plin, nbar=1e-5, BoxSize=128., Nmesh=8, seed=42)
+    source = LogNormalCatalog(Plin=Plin, nbar=1e-5, BoxSize=128., Nmesh=8, seed=42, comm=comm)
 
     decomposed = source.decompose(domain=source.pm.domain, columns=None)
 

--- a/nbodykit/base/tests/test_mesh.py
+++ b/nbodykit/base/tests/test_mesh.py
@@ -13,7 +13,6 @@ setup_logging()
 def test_lost_attrs(comm):
 
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # initialize an output directory
     if comm.rank == 0:
@@ -24,7 +23,7 @@ def test_lost_attrs(comm):
 
     # linear mesh
     Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
-    source = LinearMesh(Plin, Nmesh=64, BoxSize=512, seed=42)
+    source = LinearMesh(Plin, Nmesh=64, BoxSize=512, seed=42, comm=comm)
 
     # a hard to save attribute
     source.attrs['bad'] = cosmo.to_astropy()
@@ -42,7 +41,6 @@ def test_lost_attrs(comm):
 def test_real_save(comm):
 
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # initialize an output directory
     if comm.rank == 0:
@@ -53,7 +51,7 @@ def test_real_save(comm):
 
     # linear mesh
     Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
-    source = LinearMesh(Plin, Nmesh=64, BoxSize=512, seed=42)
+    source = LinearMesh(Plin, Nmesh=64, BoxSize=512, seed=42, comm=comm)
 
     # a hard to save attribute
     source.attrs['empty'] = None
@@ -80,7 +78,6 @@ def test_real_save(comm):
 def test_real_save(comm):
 
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # initialize an output directory
     if comm.rank == 0:
@@ -91,7 +88,7 @@ def test_real_save(comm):
 
     # linear mesh
     Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
-    source = LinearMesh(Plin, Nmesh=64, BoxSize=512, seed=42)
+    source = LinearMesh(Plin, Nmesh=64, BoxSize=512, seed=42, comm=comm)
 
     # a hard to save attribute
     source.attrs['empty'] = None
@@ -100,7 +97,7 @@ def test_real_save(comm):
     source.save(tmpfile, mode='real')
 
     # load as a BigFileMesh
-    source2 = BigFileMesh(tmpfile, dataset='Field')
+    source2 = BigFileMesh(tmpfile, dataset='Field', comm=comm)
 
     # check sources
     for k in source.attrs:
@@ -118,11 +115,10 @@ def test_real_save(comm):
 def test_preview(comm):
 
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # linear mesh
     Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
-    source = LinearMesh(Plin, Nmesh=64, BoxSize=512, seed=42)
+    source = LinearMesh(Plin, Nmesh=64, BoxSize=512, seed=42, comm=comm)
 
     # the painted RealField
     real = source.compute(mode='real')
@@ -138,11 +134,10 @@ def test_preview(comm):
 def test_resample(comm):
 
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # linear mesh
     Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
-    source = LinearMesh(Plin, Nmesh=64, BoxSize=512, seed=42)
+    source = LinearMesh(Plin, Nmesh=64, BoxSize=512, seed=42, comm=comm)
 
     # re-sample to Nmesh=32
     real = source.compute(mode='real', Nmesh=32)
@@ -162,11 +157,10 @@ def test_resample(comm):
 def test_bad_mode(comm):
 
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # linear mesh
     Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
-    source = LinearMesh(Plin, Nmesh=64, BoxSize=512, seed=42)
+    source = LinearMesh(Plin, Nmesh=64, BoxSize=512, seed=42, comm=comm)
 
     with pytest.raises(ValueError):
         field = source.to_field(mode='BAD')
@@ -179,11 +173,10 @@ def test_view(comm):
 
     from nbodykit.base.mesh import MeshSource
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # linear mesh
     Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
-    source = LinearMesh(Plin, Nmesh=64, BoxSize=512, seed=42)
+    source = LinearMesh(Plin, Nmesh=64, BoxSize=512, seed=42, comm=comm)
     source.attrs['TEST'] = 10.0
 
     # view

--- a/nbodykit/batch.py
+++ b/nbodykit/batch.py
@@ -145,8 +145,7 @@ class TaskManager(object):
 
         # split the comm between the workers
         self.comm = self.basecomm.Split(color, 0)
-        self.original_comm = CurrentMPIComm.get()
-        CurrentMPIComm.set(self.comm)
+        CurrentMPIComm.push(self.comm)
 
         return self
 
@@ -364,7 +363,7 @@ class TaskManager(object):
         if self.is_root():
             self.logger.debug("master is finished; terminating")
 
-        CurrentMPIComm.set(self.original_comm)
+        CurrentMPIComm.pop()
 
         if self.comm is not None:
             self.comm.Free()

--- a/nbodykit/source/catalog/tests/test_array.py
+++ b/nbodykit/source/catalog/tests/test_array.py
@@ -10,14 +10,13 @@ setup_logging("debug")
 def test_table(comm):
 
     from astropy.table import Table
-    CurrentMPIComm.set(comm)
 
     data = numpy.ones(100, dtype=[
             ('Position', ('f4', 3)),
             ('Velocity', ('f4', 3))]
             )
     data = Table(data)
-    source = ArrayCatalog(data, BoxSize=100, Nmesh=32)
+    source = ArrayCatalog(data, BoxSize=100, Nmesh=32, comm=comm)
 
     for col in ['Position', 'Velocity']:
         assert_array_equal(data[col], source[col])
@@ -27,12 +26,11 @@ def test_table(comm):
 def test_nonstructured_input(comm):
 
     from astropy.table import Table
-    CurrentMPIComm.set(comm)
 
     # data should be structured!
     data = numpy.ones(100)
     with pytest.raises(ValueError):
-        source = ArrayCatalog(data, BoxSize=100, Nmesh=32)
+        source = ArrayCatalog(data, BoxSize=100, Nmesh=32, comm=comm)
 
 
 
@@ -41,12 +39,12 @@ def test_nonstructured_input(comm):
 def test_array(comm):
 
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
+
     data = numpy.ones(100, dtype=[
             ('Position', ('f4', 3)),
             ('Velocity', ('f4', 3))]
             )
-    source = ArrayCatalog(data, BoxSize=100, Nmesh=32)
+    source = ArrayCatalog(data, BoxSize=100, Nmesh=32, comm=comm)
 
     assert source.csize == 100 * comm.size
     source['Velocity'] = source['Position'] + source['Velocity']
@@ -62,14 +60,14 @@ def test_array(comm):
 def test_dict(comm):
 
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
+
     data = numpy.ones(100, dtype=[
             ('Position', ('f4', 3)),
             ('Velocity', ('f4', 3))]
             )
     # use a dictionary
     data = dict(Position=data['Position'], Velocity=data['Velocity'])
-    source = ArrayCatalog(data, BoxSize=100, Nmesh=32)
+    source = ArrayCatalog(data, BoxSize=100, Nmesh=32, comm=comm)
 
     assert source.csize == 100 * comm.size
     source['Velocity'] = source['Position'] + source['Velocity']

--- a/nbodykit/source/catalog/tests/test_file.py
+++ b/nbodykit/source/catalog/tests/test_file.py
@@ -25,17 +25,14 @@ def test_hdf(comm):
         grp.create_dataset('Mass', data=dset['Mass']) # column as dataset
 
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
-    source = HDFCatalog(tmpfile, root='X', attrs={"Nmesh":32})
+    source = HDFCatalog(tmpfile, root='X', attrs={"Nmesh":32}, comm=comm)
     assert_allclose(source['Position'], dset['Position'])
 
     os.unlink(tmpfile)
 
 @MPITest([1])
 def test_csv(comm):
-
-    CurrentMPIComm.set(comm)
 
     with tempfile.NamedTemporaryFile() as ff:
 
@@ -45,7 +42,7 @@ def test_csv(comm):
 
         # read nrows
         names =['a', 'b', 'c', 'd', 'e']
-        f = CSVCatalog(ff.name, names, blocksize=100)
+        f = CSVCatalog(ff.name, names, blocksize=100, comm=comm)
 
         # make sure data is the same
         for i, name in enumerate(names):
@@ -57,7 +54,6 @@ def test_csv(comm):
 @MPITest([1])
 def test_stack_glob(comm):
 
-    CurrentMPIComm.set(comm)
     tmpfile1 = 'test-glob-1.dat'
     tmpfile2 = 'test-glob-2.dat'
 
@@ -68,7 +64,7 @@ def test_stack_glob(comm):
 
     # read using a glob
     names =['a', 'b', 'c', 'd', 'e']
-    f = CSVCatalog('test-glob-*', names, blocksize=100)
+    f = CSVCatalog('test-glob-*', names, blocksize=100, comm=comm)
 
     # make sure print works
     print(f)
@@ -87,7 +83,6 @@ def test_stack_glob(comm):
 @MPITest([1])
 def test_stack_list(comm):
 
-    CurrentMPIComm.set(comm)
     tmpfile1 = 'test-list-1.dat'
     tmpfile2 = 'test-list-2.dat'
 
@@ -98,7 +93,7 @@ def test_stack_list(comm):
 
     # read using a glob
     names =['a', 'b', 'c', 'd', 'e']
-    f = CSVCatalog(['test-list-1.dat', 'test-list-2.dat'], names, blocksize=100)
+    f = CSVCatalog(['test-list-1.dat', 'test-list-2.dat'], names, blocksize=100, comm=comm)
 
     # make sure print works
     print(f)

--- a/nbodykit/source/catalog/tests/test_fkp.py
+++ b/nbodykit/source/catalog/tests/test_fkp.py
@@ -10,11 +10,9 @@ setup_logging()
 @MPITest([4])
 def test_missing_columns(comm):
 
-    CurrentMPIComm.set(comm)
-
     # create FKP catalog
-    source1 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=42)
-    source2 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=84)
+    source1 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=42, comm=comm)
+    source2 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=84, comm=comm)
     cat = FKPCatalog(source1, source2, BoxSize=512.0, BoxPad=0.02)
 
     with pytest.raises(ValueError):
@@ -23,11 +21,9 @@ def test_missing_columns(comm):
 @MPITest([4])
 def test_boxsize(comm):
 
-    CurrentMPIComm.set(comm)
-
     # data and randoms
-    source1 = UniformCatalog(nbar=3e-3, BoxSize=512., seed=42)
-    source2 = UniformCatalog(nbar=3e-3, BoxSize=512., seed=84)
+    source1 = UniformCatalog(nbar=3e-3, BoxSize=512., seed=42, comm=comm)
+    source2 = UniformCatalog(nbar=3e-3, BoxSize=512., seed=84, comm=comm)
 
     # add required columns
     source1['NZ']  = 1.0

--- a/nbodykit/source/catalog/tests/test_halos.py
+++ b/nbodykit/source/catalog/tests/test_halos.py
@@ -8,10 +8,8 @@ setup_logging()
 @MPITest([4])
 def test_bad_init(comm):
 
-    CurrentMPIComm.set(comm)
-
     # initialize a catalog
-    cat = UniformCatalog(nbar=100, BoxSize=1.0)
+    cat = UniformCatalog(nbar=100, BoxSize=1.0, comm=comm)
     cat['Mass'] = 1.0
 
     # cannot specify column as None
@@ -25,10 +23,8 @@ def test_bad_init(comm):
 @MPITest([4])
 def test_missing_boxsize(comm):
 
-    CurrentMPIComm.set(comm)
-
     # initialize a catalog
-    cat = UniformCatalog(nbar=100, BoxSize=1.0)
+    cat = UniformCatalog(nbar=100, BoxSize=1.0, comm=comm)
     cat['Mass'] = 1.0
 
     # initialize halos

--- a/nbodykit/source/catalog/tests/test_hod.py
+++ b/nbodykit/source/catalog/tests/test_hod.py
@@ -11,9 +11,7 @@ setup_logging()
 @MPITest([1, 4])
 def test_no_seed(comm):
 
-    CurrentMPIComm.set(comm)
-
-    halos = DemoHaloCatalog('bolshoi', 'rockstar', 0.5)
+    halos = DemoHaloCatalog('bolshoi', 'rockstar', 0.5, comm=comm)
     hod = halos.populate(Zheng07Model)
 
     # seed is set randomly
@@ -22,9 +20,7 @@ def test_no_seed(comm):
 @MPITest([1, 4])
 def test_bad_model(comm):
 
-    CurrentMPIComm.set(comm)
-
-    halos = DemoHaloCatalog('bolshoi', 'rockstar', 0.5)
+    halos = DemoHaloCatalog('bolshoi', 'rockstar', 0.5, comm=comm)
     with pytest.raises(TypeError):
         hod = halos.populate('Zheng07Model')
 
@@ -32,10 +28,8 @@ def test_bad_model(comm):
 @MPITest([1, 4])
 def test_failed_populate(comm):
 
-    CurrentMPIComm.set(comm)
-
     # the demo halos
-    halos = DemoHaloCatalog('bolshoi', 'rockstar', 0.5)
+    halos = DemoHaloCatalog('bolshoi', 'rockstar', 0.5, comm=comm)
 
     # initialize model with bad MASS column
     model = Zheng07Model.to_halotools(halos.cosmo, halos.attrs['redshift'], '200c')
@@ -47,8 +41,7 @@ def test_failed_populate(comm):
 @MPITest([1, 4])
 def test_no_galaxies(comm):
 
-    CurrentMPIComm.set(comm)
-    halos = DemoHaloCatalog('bolshoi', 'rockstar', 0.5)
+    halos = DemoHaloCatalog('bolshoi', 'rockstar', 0.5, comm=comm)
 
     # no galaxies populated into halos
     # NOTE: logMmin is unrealistically large here
@@ -58,10 +51,8 @@ def test_no_galaxies(comm):
 @MPITest([1, 4])
 def test_repopulate(comm):
 
-    CurrentMPIComm.set(comm)
-
     # initialize the halos
-    halos = DemoHaloCatalog('bolshoi', 'rockstar', 0.5)
+    halos = DemoHaloCatalog('bolshoi', 'rockstar', 0.5, comm=comm)
 
     # populate the mock first
     hod = halos.populate(Zheng07Model, seed=42)
@@ -88,15 +79,13 @@ def test_repopulate(comm):
 @MPITest([1, 4])
 def test_hod_cm(comm):
 
-    CurrentMPIComm.set(comm)
-
     redshift = 0.55
     cosmo = cosmology.Planck15
     BoxSize = 512
 
     # lognormal particles
     Plin = cosmology.LinearPower(cosmo, redshift=redshift, transfer='EisensteinHu')
-    source = LogNormalCatalog(Plin=Plin, nbar=3e-3, BoxSize=BoxSize, Nmesh=128, seed=42)
+    source = LogNormalCatalog(Plin=Plin, nbar=3e-3, BoxSize=BoxSize, Nmesh=128, seed=42, comm=comm)
 
     # run FOF
     r = FOF(source, linking_length=0.2, nmin=20)
@@ -114,15 +103,13 @@ def test_hod_cm(comm):
 @MPITest([1, 4])
 def test_hod_peak(comm):
 
-    CurrentMPIComm.set(comm)
-
     redshift = 0.55
     cosmo = cosmology.Planck15
     BoxSize = 512
 
     # lognormal particles
     Plin = cosmology.LinearPower(cosmo, redshift=redshift, transfer='EisensteinHu')
-    source = LogNormalCatalog(Plin=Plin, nbar=3e-3, BoxSize=BoxSize, Nmesh=128, seed=42)
+    source = LogNormalCatalog(Plin=Plin, nbar=3e-3, BoxSize=BoxSize, Nmesh=128, seed=42, comm=comm)
 
     source['Density'] = KDDensity(source).density
 
@@ -142,15 +129,13 @@ def test_hod_peak(comm):
 @MPITest([1, 4])
 def test_save(comm):
 
-    CurrentMPIComm.set(comm)
-
     redshift = 0.55
     cosmo = cosmology.Planck15
     BoxSize = 512
 
     # lognormal particles
     Plin = cosmology.LinearPower(cosmo, redshift=redshift, transfer='EisensteinHu')
-    source = LogNormalCatalog(Plin=Plin, nbar=3e-3, BoxSize=BoxSize, Nmesh=128, seed=42)
+    source = LogNormalCatalog(Plin=Plin, nbar=3e-3, BoxSize=BoxSize, Nmesh=128, seed=42, comm=comm)
 
     # run FOF
     r = FOF(source, linking_length=0.2, nmin=20)

--- a/nbodykit/source/catalog/tests/test_lognormal.py
+++ b/nbodykit/source/catalog/tests/test_lognormal.py
@@ -12,11 +12,10 @@ setup_logging("debug")
 @MPITest([4])
 def test_lognormal_sparse(comm):
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # this should generate 15 particles
     Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
-    source = LogNormalCatalog(Plin=Plin, nbar=1e-5, BoxSize=128., Nmesh=8, seed=42)
+    source = LogNormalCatalog(Plin=Plin, nbar=1e-5, BoxSize=128., Nmesh=8, seed=42, comm=comm)
 
     mesh = source.to_mesh(compensated=False)
 
@@ -26,10 +25,9 @@ def test_lognormal_sparse(comm):
 @MPITest([1, 4])
 def test_lognormal_dense(comm):
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
-    source = LogNormalCatalog(Plin=Plin, nbar=0.2e-2, BoxSize=128., Nmesh=8, seed=42)
+    source = LogNormalCatalog(Plin=Plin, nbar=0.2e-2, BoxSize=128., Nmesh=8, seed=42, comm=comm)
     mesh = source.to_mesh(compensated=False)
 
     real = mesh.compute(mode='real')
@@ -38,10 +36,9 @@ def test_lognormal_dense(comm):
 @MPITest([4])
 def test_lognormal_invariance(comm):
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
-    source = LogNormalCatalog(Plin=Plin, nbar=0.5e-2, BoxSize=128., Nmesh=32, seed=42)
+    source = LogNormalCatalog(Plin=Plin, nbar=0.5e-2, BoxSize=128., Nmesh=32, seed=42, comm=comm)
     source1 = LogNormalCatalog(Plin=Plin, nbar=0.5e-2, BoxSize=128., Nmesh=32, seed=42, comm=MPI.COMM_SELF)
 
     assert source.csize == source1.size
@@ -54,10 +51,9 @@ def test_lognormal_invariance(comm):
 @MPITest([1])
 def test_lognormal_velocity(comm):
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
-    source = LogNormalCatalog(Plin=Plin, nbar=0.5e-2, BoxSize=128., Nmesh=32, seed=42)
+    source = LogNormalCatalog(Plin=Plin, nbar=0.5e-2, BoxSize=128., Nmesh=32, seed=42, comm=comm)
 
     source['Value'] = source['Velocity'][:, 0]**2
     mesh = source.to_mesh(compensated=False)

--- a/nbodykit/source/catalog/tests/test_species.py
+++ b/nbodykit/source/catalog/tests/test_species.py
@@ -11,10 +11,8 @@ setup_logging()
 @MPITest([1, 4])
 def test_get_syntax(comm):
 
-    CurrentMPIComm.set(comm)
-
-    source1 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=42)
-    source2 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=84)
+    source1 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=42, comm=comm)
+    source2 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=84, comm=comm)
     cat = MultipleSpeciesCatalog(['data', 'randoms'], source1, source2)
 
     # test either get syntax
@@ -30,10 +28,8 @@ def test_get_syntax(comm):
 @MPITest([1, 4])
 def test_columns(comm):
 
-    CurrentMPIComm.set(comm)
-
-    source1 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=42)
-    source2 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=84)
+    source1 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=42, comm=comm)
+    source2 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=84, comm=comm)
 
     cat = MultipleSpeciesCatalog(['data', 'randoms'], source1, source2, BoxSize=512., Nmesh=128)
 
@@ -48,10 +44,8 @@ def test_columns(comm):
 @MPITest([1, 4])
 def test_bad_input(comm):
 
-    CurrentMPIComm.set(comm)
-
-    source1 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=42)
-    source2 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=84)
+    source1 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=42, comm=comm)
+    source2 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=84, comm=comm)
 
     # need 2 species
     with pytest.raises(ValueError):
@@ -74,10 +68,8 @@ def test_bad_input(comm):
 @MPITest([1, 4])
 def test_getitem(comm):
 
-    CurrentMPIComm.set(comm)
-
-    source1 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=42)
-    source2 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=84)
+    source1 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=42, comm=comm)
+    source2 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=84, comm=comm)
 
     cat = MultipleSpeciesCatalog(['data', 'randoms'], source1, source2)
 
@@ -93,10 +85,8 @@ def test_getitem(comm):
 @MPITest([1, 4])
 def test_setitem(comm):
 
-    CurrentMPIComm.set(comm)
-
-    source1 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=42)
-    source2 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=84)
+    source1 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=42, comm=comm)
+    source2 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=84, comm=comm)
 
     cat = MultipleSpeciesCatalog(['data', 'randoms'], source1, source2)
 
@@ -119,10 +109,8 @@ def test_setitem(comm):
 @MPITest([1, 4])
 def test_bad_slice(comm):
 
-    CurrentMPIComm.set(comm)
-
-    source1 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=42)
-    source2 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=84)
+    source1 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=42, comm=comm)
+    source2 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=84, comm=comm)
 
     cat = MultipleSpeciesCatalog(['data', 'randoms'], source1, source2)
 

--- a/nbodykit/source/catalogmesh/tests/test_fkp.py
+++ b/nbodykit/source/catalogmesh/tests/test_fkp.py
@@ -10,15 +10,13 @@ setup_logging()
 @MPITest([1, 4])
 def test_paint(comm):
 
-    CurrentMPIComm.set(comm)
-
     NBAR1 = 3e-5; WEIGHT1 = 1.05
     NBAR2 = 3e-3; WEIGHT2 = 0.95
     P0_FKP = 2e4
 
     # the catalog
-    source1 = UniformCatalog(nbar=NBAR1, BoxSize=512., seed=42)
-    source2 = UniformCatalog(nbar=NBAR2, BoxSize=512., seed=84)
+    source1 = UniformCatalog(nbar=NBAR1, BoxSize=512., seed=42, comm=comm)
+    source2 = UniformCatalog(nbar=NBAR2, BoxSize=512., seed=84, comm=comm)
 
     # add completeness weights
     source1['Weight'] = WEIGHT1

--- a/nbodykit/source/catalogmesh/tests/test_species.py
+++ b/nbodykit/source/catalogmesh/tests/test_species.py
@@ -10,11 +10,9 @@ setup_logging()
 @MPITest([1])
 def test_boxsize_nmesh(comm):
 
-    CurrentMPIComm.set(comm)
-
     # the catalog
-    source1 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=42)
-    source2 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=84)
+    source1 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=42, comm=comm)
+    source2 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=84, comm=comm)
     cat = MultipleSpeciesCatalog(['data', 'randoms'], source1, source2)
 
     # this should work (infer BoxSize)
@@ -32,11 +30,9 @@ def test_boxsize_nmesh(comm):
 @MPITest([1, 4])
 def test_getitem(comm):
 
-    CurrentMPIComm.set(comm)
-
     # the catalog
-    source1 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=42)
-    source2 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=84)
+    source1 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=42, comm=comm)
+    source2 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=84, comm=comm)
     cat = MultipleSpeciesCatalog(['data', 'randoms'], source1, source2)
 
     # the mesh
@@ -49,11 +45,9 @@ def test_getitem(comm):
 @MPITest([1, 4])
 def test_compute(comm):
 
-    CurrentMPIComm.set(comm)
-
     # the catalog
-    source1 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=42)
-    source2 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=84)
+    source1 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=42, comm=comm)
+    source2 = UniformCatalog(nbar=3e-5, BoxSize=512., seed=84, comm=comm)
     cat = MultipleSpeciesCatalog(['data', 'randoms'], source1, source2)
 
     # the meshes
@@ -79,14 +73,12 @@ def test_compute(comm):
 @MPITest([1, 4])
 def test_paint_interlaced(comm):
 
-    CurrentMPIComm.set(comm)
-
     # the test case fails only if there is enough particles to trigger
     # the second loop of the interlaced painter; these parameters will do it.
 
     # the catalog
-    source1 = UniformCatalog(nbar=1e-0, BoxSize=111, seed=111)
-    source2 = UniformCatalog(nbar=1e-0, BoxSize=111, seed=111)
+    source1 = UniformCatalog(nbar=1e-0, BoxSize=111, seed=111, comm=comm)
+    source2 = UniformCatalog(nbar=1e-0, BoxSize=111, seed=111, comm=comm)
     source1['Weight'] = 1.0
     source2['Weight'] = 0.1
     cat = MultipleSpeciesCatalog(['data', 'randoms'], source1, source2)

--- a/nbodykit/source/mesh/tests/test_bigfile.py
+++ b/nbodykit/source/mesh/tests/test_bigfile.py
@@ -13,11 +13,10 @@ def test_bigfile_grid(comm):
     import tempfile
 
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # input linear mesh
     Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
-    source = LinearMesh(Plin, BoxSize=512, Nmesh=32, seed=42)
+    source = LinearMesh(Plin, BoxSize=512, Nmesh=32, seed=42, comm=comm)
 
     real = source.compute(mode='real')
     complex = source.compute(mode="complex")
@@ -32,7 +31,7 @@ def test_bigfile_grid(comm):
     source.save(output, dataset='Field')
 
     # now load it and paint to the algorithm's ParticleMesh
-    source = BigFileMesh(path=output, dataset='Field')
+    source = BigFileMesh(path=output, dataset='Field', comm=comm)
     loaded_real = source.compute()
 
     # compare to direct algorithm result
@@ -41,7 +40,7 @@ def test_bigfile_grid(comm):
     source.save(output, dataset='FieldC', mode='complex')
 
     # now load it and paint to the algorithm's ParticleMesh
-    source = BigFileMesh(path=output, dataset='FieldC')
+    source = BigFileMesh(path=output, dataset='FieldC', comm=comm)
     loaded_real = source.compute(mode="complex")
 
     # compare to direct algorithm result

--- a/nbodykit/source/mesh/tests/test_linear.py
+++ b/nbodykit/source/mesh/tests/test_linear.py
@@ -10,11 +10,10 @@ setup_logging()
 def test_paint(comm):
 
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # linear grid
     Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
-    source = LinearMesh(Plin, Nmesh=64, BoxSize=512, seed=42)
+    source = LinearMesh(Plin, Nmesh=64, BoxSize=512, seed=42, comm=comm)
 
     # compute P(k) from linear grid
     r = FFTPower(source, mode='1d', Nmesh=64, dk=0.01, kmin=0.005)

--- a/nbodykit/tests/test_batch.py
+++ b/nbodykit/tests/test_batch.py
@@ -11,58 +11,59 @@ setup_logging("debug")
 @MPITest([1])
 def test_missing_ranks(comm):
 
-    CurrentMPIComm.set(comm)
-    cpus_per_task = 2
-    with pytest.raises(ValueError):
-        with TaskManager(cpus_per_task, debug=True, use_all_cpus=True) as tm:
-            pass
+    with CurrentMPIComm.enter(comm):
+        cpus_per_task = 2
+        with pytest.raises(ValueError):
+            with TaskManager(cpus_per_task, debug=True, use_all_cpus=True) as tm:
+                pass
 
 @MPITest([2])
 def test_no_workers(comm):
 
-    CurrentMPIComm.set(comm)
-    cpus_per_task = 2
-    with pytest.raises(ValueError):
-        with TaskManager(cpus_per_task, debug=True, use_all_cpus=False) as tm:
-            pass
+    with CurrentMPIComm.enter(comm):
+        cpus_per_task = 2
+        with pytest.raises(ValueError):
+            with TaskManager(cpus_per_task, debug=True, use_all_cpus=False) as tm:
+                pass
 
 
 @MPITest([2, 4])
 def test_iterate(comm):
 
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     cpus_per_task = 2
-    with TaskManager(cpus_per_task, debug=True, use_all_cpus=True) as tm:
+    with CurrentMPIComm.enter(comm):
+        with TaskManager(cpus_per_task, debug=True, use_all_cpus=True) as tm:
 
-        try:
-            for seed in tm.iterate([0, 1, 2]):
+            try:
+                for seed in tm.iterate([0, 1, 2]):
 
-                # uniform particles
-                source = UniformCatalog(nbar=3e-7, BoxSize=1380., seed=seed)
+                    # uniform particles
+                    source = UniformCatalog(nbar=3e-7, BoxSize=1380., seed=seed)
 
-                # compute P(k,mu) and multipoles
-                r = FFTPower(source, mode='2d', Nmesh=8, poles=[0,2,4])
+                    # compute P(k,mu) and multipoles
+                    r = FFTPower(source, mode='2d', Nmesh=8, poles=[0,2,4])
 
-                # and save
-                output = "./test_batch_uniform_seed%d.json" % seed
-                r.save(output)
+                    # and save
+                    output = "./test_batch_uniform_seed%d.json" % seed
+                    r.save(output)
 
-        except Exception as e:
-            print(e)
-            raise
+            except Exception as e:
+                print(e)
+                raise
 
 @MPITest([4])
 def test_map(comm):
 
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
+
+    cpus_per_task = 2
 
     def fftpower(seed):
 
         # uniform particles
-        source = UniformCatalog(nbar=3e-7, BoxSize=1380., seed=seed)
+        source = UniformCatalog(nbar=3e-7, BoxSize=1380., seed=seed, comm=comm)
 
         # compute P(k,mu) and multipoles
         r = FFTPower(source, mode='2d', Nmesh=8, poles=[0,2,4])
@@ -73,8 +74,7 @@ def test_map(comm):
 
         return seed
 
-    cpus_per_task = 2
-    with TaskManager(cpus_per_task, debug=True, use_all_cpus=False) as tm:
+    with TaskManager(cpus_per_task, debug=True, use_all_cpus=False, comm=comm) as tm:
 
         try:
             seeds = [0, 1, 2]

--- a/nbodykit/tests/test_cache.py
+++ b/nbodykit/tests/test_cache.py
@@ -1,9 +1,11 @@
 from nbodykit import GlobalCache
 from nbodykit.lab import UniformCatalog
 
-def test_cache():
+from runtests.mpi import MPITest
 
-    cat = UniformCatalog(nbar=10000, BoxSize=1.0)
+@MPITest([1])
+def test_cache(comm):
+    cat = UniformCatalog(nbar=10000, BoxSize=1.0, comm=comm)
     cat['test'] = cat['Position'] ** 5
     test = cat['test'].compute()
 

--- a/nbodykit/tests/test_lab.py
+++ b/nbodykit/tests/test_lab.py
@@ -9,65 +9,62 @@ setup_logging("debug")
 def test_fftpower(comm):
     cosmo = cosmology.Planck15
 
-    CurrentMPIComm.set(comm)
+    with CurrentMPIComm.enter(comm):
+        # lognormal particles
+        Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
+        source = LogNormalCatalog(Plin=Plin, nbar=3e-7, BoxSize=1380., Nmesh=8, seed=42)
 
-    # lognormal particles
-    Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
-    source = LogNormalCatalog(Plin=Plin, nbar=3e-7, BoxSize=1380., Nmesh=8, seed=42)
+        # apply RSD
+        source['Position'] += source['VelocityOffset'] * [0,0,1]
 
-    # apply RSD
-    source['Position'] += source['VelocityOffset'] * [0,0,1]
+        # compute P(k,mu) and multipoles
+        result = FFTPower(source, mode='2d', poles=[0,2,4], los=[0,0,1])
 
-    # compute P(k,mu) and multipoles
-    result = FFTPower(source, mode='2d', poles=[0,2,4], los=[0,0,1])
-
-    # and save
-    output = "./test_fftpower-%d.json" % comm.size
-    result.save(output)
+        # and save
+        output = "./test_fftpower-%d.json" % comm.size
+        result.save(output)
 
 @MPITest([1, 4])
 def test_compute(comm):
     cosmo = cosmology.Planck15
 
-    CurrentMPIComm.set(comm)
+    with CurrentMPIComm.enter(comm):
+        # lognormal particles
+        Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
+        source = LogNormalCatalog(Plin=Plin, nbar=3e-7, BoxSize=1380., Nmesh=8, seed=42)
 
-    # lognormal particles
-    Plin = cosmology.LinearPower(cosmo, redshift=0.55, transfer='EisensteinHu')
-    source = LogNormalCatalog(Plin=Plin, nbar=3e-7, BoxSize=1380., Nmesh=8, seed=42)
+        # apply RSD
+        source['Position'] += source['VelocityOffset'] * [0,0,1]
 
-    # apply RSD
-    source['Position'] += source['VelocityOffset'] * [0,0,1]
+        # convert to mesh, with Painter specifics
+        source = source.to_mesh(Nmesh=64, BoxSize=1380., interlaced=True, window='tsc', compensated=True)
 
-    # convert to mesh, with Painter specifics
-    source = source.to_mesh(Nmesh=64, BoxSize=1380., interlaced=True, window='tsc', compensated=True)
+        def filter(k, v):
+            kk = sum(ki ** 2 for ki in k)
+            kk[kk == 0] = 1
+            return v / kk
 
-    def filter(k, v):
-        kk = sum(ki ** 2 for ki in k)
-        kk[kk == 0] = 1
-        return v / kk
+        source = source.apply(filter)
 
-    source = source.apply(filter)
+        real = source.compute(mode='real')
+        complex = source.compute(mode='complex')
 
-    real = source.compute(mode='real')
-    complex = source.compute(mode='complex')
-
-    source.save(output="./test_paint-real-%d.bigfile" % comm.size, mode='real')
-    source.save(output="./test_paint-complex-%d.bigfile" % comm.size, mode='complex')
+        source.save(output="./test_paint-real-%d.bigfile" % comm.size, mode='real')
+        source.save(output="./test_paint-complex-%d.bigfile" % comm.size, mode='complex')
 
 @MPITest([1, 4])
 def test_set_options(comm):
 
-    CurrentMPIComm.set(comm)
+    with CurrentMPIComm.enter(comm):
+        with set_options(global_cache_size=5e9, dask_chunk_size=75):
+            s = UniformCatalog(1000, 1.0)
 
-    with set_options(global_cache_size=5e9, dask_chunk_size=75):
+            # check cache size
+            cache = GlobalCache.get()
+            assert cache.cache.available_bytes == 5e9
+
+            # check chunk size
+            assert s['Position'].chunks[0][0] == 75
+
         s = UniformCatalog(1000, 1.0)
-
-        # check cache size
-        cache = GlobalCache.get()
-        assert cache.cache.available_bytes == 5e9
-
-        # check chunk size
-        assert s['Position'].chunks[0][0] == 75
-
-    s = UniformCatalog(1000, 1.0)
-    assert s['Position'].chunks[0][0] == s.size
+        assert s['Position'].chunks[0][0] == s.size

--- a/nbodykit/tests/test_meshtools.py
+++ b/nbodykit/tests/test_meshtools.py
@@ -13,7 +13,6 @@ setup_logging("debug")
 @MPITest([1])
 def test_wrong_ndim(comm):
 
-    CurrentMPIComm.set(comm)
     numpy.random.seed(42)
 
     pm = ParticleMesh(BoxSize=8.0, Nmesh=[8,8], comm=comm, dtype='f8')
@@ -29,7 +28,6 @@ def test_wrong_ndim(comm):
 @MPITest([1])
 def test_wrong_coords_shape(comm):
 
-    CurrentMPIComm.set(comm)
     numpy.random.seed(42)
 
     pm = ParticleMesh(BoxSize=8.0, Nmesh=[8, 8], comm=comm, dtype='f8')
@@ -48,7 +46,6 @@ def test_wrong_coords_shape(comm):
 @MPITest([1, 4])
 def test_2d_slab(comm):
 
-    CurrentMPIComm.set(comm)
     numpy.random.seed(42)
 
     pm = ParticleMesh(BoxSize=8.0, Nmesh=[8, 8], comm=comm, dtype='f8')
@@ -66,7 +63,6 @@ def test_2d_slab(comm):
 @MPITest([1, 4])
 def test_hermitian_weights(comm):
 
-    CurrentMPIComm.set(comm)
     numpy.random.seed(42)
 
     pm = ParticleMesh(BoxSize=8.0, Nmesh=[8, 8, 8], comm=comm, dtype='f8')

--- a/nbodykit/tests/test_transform.py
+++ b/nbodykit/tests/test_transform.py
@@ -11,10 +11,9 @@ setup_logging("debug")
 def test_sky_to_cartesian(comm):
 
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # make source
-    s = RandomCatalog(csize=100, seed=42)
+    s = RandomCatalog(csize=100, seed=42, comm=comm)
 
     # ra, dec, z
     s['z']   = s.rng.normal(loc=0.5, scale=0.1)
@@ -34,10 +33,9 @@ def test_sky_to_cartesian(comm):
 
 @MPITest([1, 4])
 def test_cartesian_to_equatorial(comm):
-    CurrentMPIComm.set(comm)
 
     # make source
-    s = UniformCatalog(nbar=10000, BoxSize=1.0)
+    s = UniformCatalog(nbar=10000, BoxSize=1.0, comm=comm)
 
     # get RA, DEC
     ra, dec = transform.CartesianToEquatorial(s['Position'], observer=[0.5, 0.5, 0.5])
@@ -49,10 +47,9 @@ def test_cartesian_to_equatorial(comm):
 @MPITest([1, 4])
 def test_cartesian_to_sky(comm):
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # make source
-    s = UniformCatalog(nbar=10000, BoxSize=1.0, seed=42)
+    s = UniformCatalog(nbar=10000, BoxSize=1.0, seed=42, comm=comm)
 
     # get RA, DEC, Z
     ra, dec, z = transform.CartesianToSky(s['Position'], cosmo)
@@ -68,10 +65,9 @@ def test_cartesian_to_sky(comm):
 @MPITest([1, 4])
 def test_cartesian_to_sky_velocity(comm):
     cosmo = cosmology.Planck15
-    CurrentMPIComm.set(comm)
 
     # make source
-    s = UniformCatalog(nbar=1e-5, BoxSize=1380., seed=42)
+    s = UniformCatalog(nbar=1e-5, BoxSize=1380., seed=42, comm=comm)
 
     # real-space redshift
     _, _, z_real = transform.CartesianToSky(s['Position'], cosmo,
@@ -92,10 +88,9 @@ def test_cartesian_to_sky_velocity(comm):
 
 @MPITest([1, 4])
 def test_stack_columns(comm):
-    CurrentMPIComm.set(comm)
 
     # make source
-    s = RandomCatalog(csize=100, seed=42)
+    s = RandomCatalog(csize=100, seed=42, comm=comm)
 
     # add x,y,z
     s['x'] = s.rng.uniform(0, 2600.)
@@ -116,11 +111,10 @@ def test_stack_columns(comm):
 
 @MPITest([1, 4])
 def test_combine(comm):
-    CurrentMPIComm.set(comm)
 
     # make two sources
-    s1 = UniformCatalog(3e-6, 2600)
-    s2 = UniformCatalog(3e-6, 2600)
+    s1 = UniformCatalog(3e-6, 2600, comm=comm)
+    s2 = UniformCatalog(3e-6, 2600, comm=comm)
 
     # concatenate all columns
     cat = transform.ConcatenateSources(s1, s2)

--- a/nbodykit/tests/test_utils.py
+++ b/nbodykit/tests/test_utils.py
@@ -15,7 +15,6 @@ def test_json_quantity(comm):
     import json
     import tempfile
 
-    CurrentMPIComm.set(comm)
     cosmo = cosmology.Planck15
 
     # astropy quantity
@@ -43,7 +42,6 @@ def test_json_quantity(comm):
 
 @MPITest([2])
 def test_gather_array(comm):
-    CurrentMPIComm.set(comm)
 
     # object arrays must fail
     data1a = numpy.ones(10, dtype=[('test', 'f8')])
@@ -74,7 +72,6 @@ def test_gather_array(comm):
 
 @MPITest([2])
 def test_gather_objects(comm):
-    CurrentMPIComm.set(comm)
 
     # object arrays must fail
     data1 = numpy.ones(10, dtype=[('test', 'O')])
@@ -94,7 +91,6 @@ def test_gather_objects(comm):
 
 @MPITest([2])
 def test_scatter_objects(comm):
-    CurrentMPIComm.set(comm)
 
     # object arrays must fail
     if comm.rank == 0:
@@ -112,7 +108,6 @@ def test_scatter_objects(comm):
 
 @MPITest([2])
 def test_gather_bad_data(comm):
-    CurrentMPIComm.set(comm)
 
     # data
     if comm.rank == 0:
@@ -129,7 +124,6 @@ def test_gather_bad_data(comm):
 
 @MPITest([2])
 def test_gather_bad_dtype(comm):
-    CurrentMPIComm.set(comm)
 
     # data
     if comm.rank == 0:
@@ -146,7 +140,6 @@ def test_gather_bad_dtype(comm):
 
 @MPITest([2])
 def test_gather_bad_shape(comm):
-    CurrentMPIComm.set(comm)
 
     # data
     if comm.rank == 0:
@@ -163,7 +156,6 @@ def test_gather_bad_shape(comm):
 
 @MPITest([2])
 def test_gather_list(comm):
-    CurrentMPIComm.set(comm)
 
     # data
     data = numpy.ones(10, dtype=[('a', 'f')])
@@ -177,7 +169,6 @@ def test_gather_list(comm):
 
 @MPITest([2])
 def test_scatter_list(comm):
-    CurrentMPIComm.set(comm)
 
     # data
     if comm.rank == 0:
@@ -192,7 +183,6 @@ def test_scatter_list(comm):
 
 @MPITest([2])
 def test_scatter_wrong_counts(comm):
-    CurrentMPIComm.set(comm)
 
     # data
     if comm.rank == 0:
@@ -210,7 +200,6 @@ def test_scatter_wrong_counts(comm):
 
 @MPITest([4])
 def test_frontpad_array(comm):
-    CurrentMPIComm.set(comm)
 
     # object arrays must fail
     data1 = numpy.ones(10) * comm.rank

--- a/nbodykit/tutorials/tests/test_halos.py
+++ b/nbodykit/tutorials/tests/test_halos.py
@@ -1,6 +1,6 @@
 from runtests.mpi import MPITest
 from nbodykit.tutorials import DemoHaloCatalog
-from nbodykit import setup_logging, CurrentMPIComm
+from nbodykit import setup_logging
 import pytest
 
 setup_logging()
@@ -9,10 +9,9 @@ setup_logging()
 def test_download(comm):
 
     from halotools.sim_manager import UserSuppliedHaloCatalog
-    CurrentMPIComm.set(comm)
 
     # download and load the cached catalog
-    cat = DemoHaloCatalog('bolshoi', 'rockstar', 0.5)
+    cat = DemoHaloCatalog('bolshoi', 'rockstar', 0.5, comm=comm)
     assert all(col in cat for col in ['Position', 'Velocity'])
 
     # convert to halotools catalog
@@ -26,9 +25,7 @@ def test_download(comm):
 
 @MPITest([4])
 def test_download_failure(comm):
-    CurrentMPIComm.set(comm)
-
     # initialize with bad redshift
     BAD_REDSHIFT = 100.0
     with pytest.raises(Exception):
-        cat = DemoHaloCatalog('bolshoi', 'rockstar', BAD_REDSHIFT)
+        cat = DemoHaloCatalog('bolshoi', 'rockstar', BAD_REDSHIFT, comm=comm)


### PR DESCRIPTION
This PR reworks CurrentMPIComm:

1. Test cases become more predictable by directly supplying the communicator. Previously the default communicator entering a test is unpredictable. 

2. CurrentMPIComm.set is deprecated, replaced by CurrentMPIComm.enter, which is a contextmanager that restores the previous default communicator.

3. TaskManager uses push and pop, potentially allowing nesting.