### PR TITLE
Reduce the paint size for systems with lower mem per core

### DIFF
--- a/nbodykit/__init__.py
+++ b/nbodykit/__init__.py
@@ -18,7 +18,7 @@ except:
 _global_options = {}
 _global_options['global_cache_size'] = 1e8 # 100 MB
 _global_options['dask_chunk_size'] = 100000
-_global_options['paint_chunk_size'] = 1024 * 1024 * 8
+_global_options['paint_chunk_size'] = 1024 * 1024 * 4
 
 from contextlib import contextmanager
 import logging


### PR DESCRIPTION
We really shall look into rewriting the paint algorithm with dask,
off loading the memory usage bound to dask.