### PR TITLE
Improve usage under pure dask cluster mode.

### DIFF
--- a/nbodykit/__init__.py
+++ b/nbodykit/__init__.py
@@ -28,11 +28,11 @@ def _unpickle(name):
 
 def _comm_pickle(obj):
     if obj == MPI.COMM_NULL:
-        return unpickle, ('COMM_NULL',)
+        return _unpickle, ('COMM_NULL',)
     if obj == MPI.COMM_SELF:
-        return unpickle, ('COMM_SELF',)
+        return _unpickle, ('COMM_SELF',)
     if obj == MPI.COMM_WORLD:
-        return unpickle, ('COMM_WORLD',)
+        return _unpickle, ('COMM_WORLD',)
     raise TypeError("cannot pickle object")
 
 def _setup_for_distributed():

--- a/nbodykit/__init__.py
+++ b/nbodykit/__init__.py
@@ -69,6 +69,7 @@ def use_distributed(c=None):
         import distributed
         c = distributed.get_client()
 
+    _setup_for_distributed()
     c.register_worker_callbacks(setup=_setup_for_distributed)
 
 def use_mpi(comm=None):

--- a/nbodykit/base/catalog.py
+++ b/nbodykit/base/catalog.py
@@ -589,7 +589,7 @@ class CatalogSourceBase(object):
         if len(datasets) != len(columns):
             raise ValueError("`datasets` must have the same length as `columns`")
 
-        with bigfile.BigFileMPI(comm=self.comm, filename=output, create=True) as ff:
+        with bigfile.FileMPI(comm=self.comm, filename=output, create=True) as ff:
             try:
                 bb = ff.open(header)
             except:

--- a/nbodykit/base/catalog.py
+++ b/nbodykit/base/catalog.py
@@ -1,5 +1,5 @@
 from nbodykit.transform import ConstantArray
-from nbodykit import _global_options, CurrentMPIComm, GlobalCache
+from nbodykit import _global_options, CurrentMPIComm
 
 from six import string_types, add_metaclass
 import numpy
@@ -522,13 +522,7 @@ class CatalogSourceBase(object):
         This should be called on the return value of :func:`read`
         to converts any dask arrays to numpy arrays.
 
-        This uses the global cache as controlled by
-        :class:`nbodykit.GlobalCache` to cache dask task computations.
-        The default size is controlled by the ``global_cache_size`` global
-        option; see :class:`set_options`. To set the size, see
-        :func:`nbodykit.GlobalCache.resize`.
-
-        .. note::
+        . note::
             If the :attr:`base` attribute is set, ``compute()``
             will called using :attr:`base` instead of ``self``.
 
@@ -546,9 +540,7 @@ class CatalogSourceBase(object):
         if self.base is not None:
             return self.base.compute(*args, **kwargs)
 
-        # compute using global cache
-        with GlobalCache.get():
-            toret = dask.compute(*args, **kwargs)
+        toret = dask.compute(*args, **kwargs)
 
         # do not return tuples of length one
         if len(toret) == 1: toret = toret[0]

--- a/nbodykit/base/mesh.py
+++ b/nbodykit/base/mesh.py
@@ -373,7 +373,7 @@ class MeshSource(object):
 
         field = self.compute(mode=mode)
 
-        with bigfile.BigFileMPI(self.pm.comm, output, create=True) as ff:
+        with bigfile.FileMPI(self.pm.comm, output, create=True) as ff:
             data = numpy.empty(shape=field.size, dtype=field.dtype)
             field.ravel(out=data)
             with ff.create_from_array(dataset, data) as bb:

--- a/nbodykit/base/tests/test_catalog.py
+++ b/nbodykit/base/tests/test_catalog.py
@@ -128,9 +128,9 @@ def test_tomesh(comm):
     with pytest.raises(ValueError):
         mesh = source.to_mesh(Nmesh=128, weight='Weight3')
 
-    # bad window name
+    # bad resampler name
     with pytest.raises(ValueError):
-        mesh = source.to_mesh(Nmesh=128, weight='Weight0', window='bad_window')
+        mesh = source.to_mesh(Nmesh=128, weight='Weight0', resampler='bad_window')
 
     # missing Nmesh
     with pytest.raises(ValueError):

--- a/nbodykit/io/base.py
+++ b/nbodykit/io/base.py
@@ -116,8 +116,8 @@ class FileType(object):
         return iter(self.keys())
 
     def __repr__(self):
-        args = (self.__class__.__name__, self.ncol, self.shape)
-        return "<%s with %d column(s) and shape %s>" %args
+        args = (self.__class__.__name__, self.path, self.dataset if hasattr(self, 'dataset') else "None", self.ncol, self.shape)
+        return "%s(path=%s, dataset=%s, ncolumns=%d, shape=%s>" % args
 
     def __contains__(self, col):
         return col in self.columns

--- a/nbodykit/io/bigfile.py
+++ b/nbodykit/io/bigfile.py
@@ -58,7 +58,7 @@ class BigFile(FileType):
         self.attrs = {}
 
         # the file path
-        with bigfile.BigFile(filename=path) as ff:
+        with bigfile.File(filename=path) as ff:
             columns = [block for block in ff[self.dataset].blocks]
             headers = self._find_headers(header, dataset, ff)
 
@@ -74,7 +74,7 @@ class BigFile(FileType):
                 for column in set(columns) if not any(fnmatch(column, e) for e in exclude)
                 ]
 
-            ds = bigfile.BigData(ff[self.dataset], columns)
+            ds = bigfile.Dataset(ff[self.dataset], columns)
 
             # set the data type and size
             self.dtype = ds.dtype
@@ -129,6 +129,6 @@ class BigFile(FileType):
         import bigfile
         if isinstance(columns, string_types): columns = [columns]
 
-        with bigfile.BigFile(filename=self.path)[self.dataset] as f:
-            ds = bigfile.BigData(f, columns)
+        with bigfile.File(filename=self.path)[self.dataset] as f:
+            ds = bigfile.Dataset(f, columns)
             return ds[start:stop][::step]

--- a/nbodykit/io/binary.py
+++ b/nbodykit/io/binary.py
@@ -70,6 +70,7 @@ class BinaryFile(FileType):
     def __init__(self, path, dtype, offsets=None, header_size=0, size=None):
 
         self.path = path
+        self.dataset = "*"
 
         # set the data type
         self.dtype = dtype

--- a/nbodykit/io/csv.py
+++ b/nbodykit/io/csv.py
@@ -245,6 +245,7 @@ class CSVFile(FileType):
                     usecols=None, delim_whitespace=True, **config):
 
         self.path      = path
+        self.dataset   = "*"
         self.names     = names if usecols is None else usecols
         self.blocksize = blocksize
 

--- a/nbodykit/io/fits.py
+++ b/nbodykit/io/fits.py
@@ -28,6 +28,7 @@ class FITSFile(FileType):
             raise ImportError("please install fitsio: ``conda install -c bccp fitsio``")
 
         self.path = path
+        self.dataset = str(ext)
 
         # try to find the first Table HDU to read if not specified
         with fitsio.FITS(path) as ff:

--- a/nbodykit/io/gadget.py
+++ b/nbodykit/io/gadget.py
@@ -159,7 +159,7 @@ class Gadget1File(BinaryFile):
         self.defs = defs
 
         BinaryFile.__init__(self, path, dtype=dtype, header_size=256+4+4, offsets=offsets, size=int(header['Npart'][ptype]))
-
+        self.dataset = str(ptype)
 
     def read(self, columns, start, stop, step=1):
         """

--- a/nbodykit/io/stack.py
+++ b/nbodykit/io/stack.py
@@ -56,6 +56,9 @@ class FileStack(FileType):
         self.dtype = self.files[0].dtype
         self.size  = self.sizes.sum()
 
+    def __repr__(self):
+        return "FileStack(%s, ... %d files)" % (repr(self.files[0]), self.nfiles)
+
     @property
     def attrs(self):
         """

--- a/nbodykit/io/tests/test_bigfile.py
+++ b/nbodykit/io/tests/test_bigfile.py
@@ -16,7 +16,7 @@ def temporary_data():
         data['Velocity'] = numpy.random.random(size=(1024,3))
 
         tmpdir = tempfile.mkdtemp()
-        with bigfile.BigFile(tmpdir, create=True) as tmpff:
+        with bigfile.File(tmpdir, create=True) as tmpff:
             with tmpff.create("Position", dtype=('f4', 3), size=1024) as bb:
                 bb.write(0, data['Position'])
             with tmpff.create("Velocity", dtype=('f4', 3), size=1024) as bb:

--- a/nbodykit/mockmaker.py
+++ b/nbodykit/mockmaker.py
@@ -304,7 +304,7 @@ def poisson_sample_to_points(delta, displacement, pm, nbar, bias=1., seed=None, 
     # generate poissons. Note that we use ravel/unravel to
     # maintain MPI invariane.
     Nravel = rng.poisson(lam=cellmean.ravel())
-    N = delta.pm.create(mode='real')
+    N = delta.pm.create(type='real')
     N.unravel(Nravel)
 
     Ntot = N.csum()

--- a/nbodykit/source/catalog/file.py
+++ b/nbodykit/source/catalog/file.py
@@ -56,19 +56,16 @@ class FileCatalogBase(CatalogSource):
         self.attrs.update(self._source.attrs)
 
         if self.comm.rank == 0:
-            self.logger.info("Extra arguments to FileType: %s" % str(args))
+            self.logger.info("Extra arguments to FileType: %s" % str(args, kwargs))
 
         CatalogSource.__init__(self, comm=comm)
 
     def __repr__(self):
         path = self._source.path
         name = self.__class__.__name__
-        if isinstance(path, string_types):
-            args = (name, self.size, os.path.basename(path))
-            return "%s(size=%d, file='%s')" % args
-        else:
-            args = (name, self.size, self._source.nfiles)
-            return "%s(size=%d, nfiles=%d)" % args
+        args = (name, self.size, repr(self.source))
+
+        return "%s(size=%d, %s)" % args
 
     @property
     def hardcolumns(self):

--- a/nbodykit/source/catalog/file.py
+++ b/nbodykit/source/catalog/file.py
@@ -56,7 +56,7 @@ class FileCatalogBase(CatalogSource):
         self.attrs.update(self._source.attrs)
 
         if self.comm.rank == 0:
-            self.logger.info("Extra arguments to FileType: %s" % str(args, kwargs))
+            self.logger.info("Extra arguments to FileType: %s %s" % (str(args), str(kwargs)))
 
         CatalogSource.__init__(self, comm=comm)
 

--- a/nbodykit/source/catalog/file.py
+++ b/nbodykit/source/catalog/file.py
@@ -63,7 +63,7 @@ class FileCatalogBase(CatalogSource):
     def __repr__(self):
         path = self._source.path
         name = self.__class__.__name__
-        args = (name, self.size, repr(self.source))
+        args = (name, self.size, repr(self._source))
 
         return "%s(size=%d, %s)" % args
 

--- a/nbodykit/source/mesh/bigfile.py
+++ b/nbodykit/source/mesh/bigfile.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from nbodykit.base.mesh import MeshSource
 from nbodykit import CurrentMPIComm
 from nbodykit.utils import JSONDecoder
-from bigfile import BigFileMPI
+from bigfile import FileMPI
 from pmesh.pm import ParticleMesh, ComplexField, RealField
 
 import numpy
@@ -43,7 +43,7 @@ class BigFileMesh(MeshSource):
 
         # update the meta-data
         self.attrs.update(kwargs)
-        with BigFileMPI(comm=self.comm, filename=path)[dataset] as ff:
+        with FileMPI(comm=self.comm, filename=path)[dataset] as ff:
             for key in ff.attrs:
                 v = ff.attrs[key]
                 if isinstance(v, string_types) and v.startswith('json://'):
@@ -96,7 +96,7 @@ class BigFileMesh(MeshSource):
         # the real field to paint to
         pmread = self.pm
 
-        with BigFileMPI(comm=self.comm, filename=self.path)[self.dataset] as ds:
+        with FileMPI(comm=self.comm, filename=self.path)[self.dataset] as ds:
             if self.comm.rank == 0:
                 self.logger.info("reading real field from %s" % self.path)
             real2 = RealField(pmread)
@@ -126,7 +126,7 @@ class BigFileMesh(MeshSource):
         if self.comm.rank == 0:
             self.logger.info("reading complex field from %s" % self.path)
 
-        with BigFileMPI(comm=self.comm, filename=self.path)[self.dataset] as ds:
+        with FileMPI(comm=self.comm, filename=self.path)[self.dataset] as ds:
             complex2 = ComplexField(pmread)
             assert self.comm.allreduce(complex2.size) == ds.size
             start = sum(self.comm.allgather(complex2.size)[:self.comm.rank])

--- a/nbodykit/source/mesh/catalog.py
+++ b/nbodykit/source/mesh/catalog.py
@@ -279,9 +279,9 @@ class CatalogMesh(MeshSource):
 
             # if we are receiving too many particles, abort and retry with a smaller chunksize
             newlengths = pm.comm.allgather(lay.newlength)
-            if any(newlengths > 2 * max_chunksize)):
+            if any([newlength > 2 * max_chunksize for newlength in newlengths]):
                 if pm.comm.rank == 0:
-                    self.logger.info("Throttling chunksize as some ranks will receive too many particles. (%d > %d)" % max(newlengths, max_chunksize * 2))
+                    self.logger.info("Throttling chunksize as some ranks will receive too many particles. (%d > %d)" % (max(newlengths), max_chunksize * 2))
                 raise StopIteration
 
             p = lay.exchange(position)

--- a/nbodykit/source/mesh/catalog.py
+++ b/nbodykit/source/mesh/catalog.py
@@ -278,9 +278,10 @@ class CatalogMesh(MeshSource):
                 lay = pm.decompose(position, smoothing=1.0 * resampler.support)
 
             # if we are receiving too many particles, abort and retry with a smaller chunksize
-            if any(pm.comm.allgather(lay.newlength > 2 * max_chunksize)):
+            newlengths = pm.comm.allgather(lay.newlength)
+            if any(newlengths > 2 * max_chunksize)):
                 if pm.comm.rank == 0:
-                    self.logger.info("Throttling chunksize as some ranks will receive too many particles.")
+                    self.logger.info("Throttling chunksize as some ranks will receive too many particles. (%d > %d)" % max(newlengths, max_chunksize * 2))
                 raise StopIteration
 
             p = lay.exchange(position)

--- a/nbodykit/source/mesh/catalog.py
+++ b/nbodykit/source/mesh/catalog.py
@@ -314,11 +314,12 @@ class CatalogMesh(MeshSource):
 
             try:
                 Nlocal1, Wlocal1 = dochunk(s)
+                chunksize = min(max_chunksize, int(chunksize * 1.5))
             except StopIteration:
                 chunksize = chunksize / 2
                 if chunksize < 1:
                     raise RuntimeError("Cannot find a chunksize that fits into memory.")
-                continue    
+                continue
             finally:
                 # collect unfreed items
                 gc.collect()

--- a/nbodykit/tests/test_cache.py
+++ b/nbodykit/tests/test_cache.py
@@ -11,8 +11,11 @@ def test_cache(comm):
 
     # cache should no longer be empty
     cache = GlobalCache.get()
+
     assert cache.cache.total_bytes > 0
 
     # resize
-    GlobalCache.resize(100)
+    cache.cache.available_bytes = 100
+    cache.cache.shrink()
+
     assert cache.cache.total_bytes < 100

--- a/nbodykit/tests/test_options.py
+++ b/nbodykit/tests/test_options.py
@@ -1,5 +1,6 @@
-from nbodykit import set_options, GlobalCache
+from nbodykit import set_options, GlobalCache, use_distributed, use_mpi
 import pytest
+from runtests.mpi import MPITest
 
 def test_bad_options():
     with pytest.raises(KeyError):
@@ -10,3 +11,13 @@ def test_cache_size():
     with set_options(global_cache_size=100):
         cache = GlobalCache.get()
         assert cache.cache.available_bytes == 100
+
+@MPITest([1])
+def test_use_distributed(comm):
+    from distributed import LocalCluster, Client
+    cluster = LocalCluster(n_workers=1, threads_per_worker=1, processes=False)
+    use_distributed(Client(cluster))
+
+@MPITest([1, 4])
+def test_use_mpi(comm):
+    use_mpi(comm)


### PR DESCRIPTION
Combined with several threading fixes in bigfile, this PR improves the support with dask clusters.

Two new functions are added: nbodykit.use_distributed and nbodykit.use_mpi. For dask clusters, initialize using use_distributed. for MPI clustrers, initialize using use_mpi. The MPI cluster mode is the default.

The global cache context manager is removed. The opportunistic caching it is now always enabled in MPI mode (when dask's synchronous scheduler is used); and always disabled in distributed mode, when the distributed scheduler is used.

The pickling trick was from mpi4py's bitbucket issue : https://bitbucket.org/mpi4py/mpi4py/issues/104/#comment-47225639

The singleton initialization needs to be revisited after the distributed PR https://github.com/dask/distributed/pull/2391 is merged.