### PR TITLE
when summing integers, use numpy.sum.

### DIFF
--- a/nbodykit/algorithms/fof.py
+++ b/nbodykit/algorithms/fof.py
@@ -224,7 +224,7 @@ def _assign_labels(minid, comm, thresh):
     # we need to work in sorted fofid
     data['fofid'] = minid
     data['origind'] = numpy.arange(len(data), dtype='u4')
-    data['origind'] += sum(comm.allgather(len(data))[:comm.rank]) \
+    data['origind'] += numpy.sum(comm.allgather(len(data))[:comm.rank], dtype='intp') \
 
     data = DistributedArray(data, comm)
 
@@ -284,7 +284,7 @@ def _fof_local(layout, pos, boxsize, ll, comm):
     del fof
 
     PID = numpy.arange(N, dtype='intp')
-    PID += sum(comm.allgather(N)[:comm.rank])
+    PID += numpy.sum(comm.allgather(N)[:comm.rank], dtype='intp')
 
     PID = layout.exchange(PID)
     # initialize global labels
@@ -696,7 +696,7 @@ class DistributedArray(object):
             else:
                 Nunique = len(junk)
 
-        label += sum(self.comm.allgather(Nunique)[:self.comm.rank])
+        label += numpy.sum(self.comm.allgather(Nunique)[:self.comm.rank], dtype='intp')
         return DistributedArray(label, self.comm)
 
     def bincount(self, local=False):

--- a/nbodykit/base/catalog.py
+++ b/nbodykit/base/catalog.py
@@ -1043,7 +1043,7 @@ class CatalogSource(CatalogSourceBase):
 
         Note that slicing changes this index value.
         """
-        offset = sum(self.comm.allgather(self.size)[:self.comm.rank])
+        offset = numpy.sum(self.comm.allgather(self.size)[:self.comm.rank], dtype='intp')
         # do not use u8, because many numpy casting rules case u8 to f8 automatically.
         # it is ridiculous.
         return da.arange(offset, offset + self.size, dtype='i8',

--- a/nbodykit/io/csv.py
+++ b/nbodykit/io/csv.py
@@ -306,7 +306,7 @@ class CSVFile(FileType):
 
         # make the partitions
         self.partitions, self._sizes = make_partitions(path, blocksize, self.pandas_config)
-        self.size = sum(self._sizes)
+        self.size = numpy.sum(self._sizes, dtype='intp')
 
     def read(self, columns, start, stop, step=1):
         """

--- a/nbodykit/source/mesh/bigfile.py
+++ b/nbodykit/source/mesh/bigfile.py
@@ -100,7 +100,7 @@ class BigFileMesh(MeshSource):
             if self.comm.rank == 0:
                 self.logger.info("reading real field from %s" % self.path)
             real2 = RealField(pmread)
-            start = sum(self.comm.allgather(real2.size)[:self.comm.rank])
+            start = numpy.sum(self.comm.allgather(real2.size)[:self.comm.rank], dtype='intp')
             end = start + real2.size
             real2.unsort(ds[start:end])
 
@@ -129,7 +129,7 @@ class BigFileMesh(MeshSource):
         with BigFileMPI(comm=self.comm, filename=self.path)[self.dataset] as ds:
             complex2 = ComplexField(pmread)
             assert self.comm.allreduce(complex2.size) == ds.size
-            start = sum(self.comm.allgather(complex2.size)[:self.comm.rank])
+            start = numpy.sum(self.comm.allgather(complex2.size)[:self.comm.rank], dtype='intp')
             end = start + complex2.size
             complex2.unsort(ds[start:end])
 

--- a/nbodykit/transform.py
+++ b/nbodykit/transform.py
@@ -79,7 +79,7 @@ def ConcatenateSources(*sources, **kwargs):
             raise ValueError(("cannot concatenate sources: columns are missing "
                               "from some sources"))
     # the total size
-    size = sum(src.size for src in sources)
+    size = numpy.sum([src.size for src in sources], dtype='intp')
 
     data = {}
     for col in columns:


### PR DESCRIPTION
On some occasions when code is ran in e.g. a notebook,
numpy.sum is imported to replace sum, and the behaviro of
numpy.sum([]) is to 0.0 rather than builtin.sum([]) which returns 0.

numpy.sum([]) returning 0.0 causes downstream code expecting integers to fail,
thus copying the code out of nbodykit won't work.

We shall not serve as an poor example in this context.