### PR TITLE
A few improvements to slicing of a catalog.

### DIFF
--- a/nbodykit/base/catalog.py
+++ b/nbodykit/base/catalog.py
@@ -281,8 +281,9 @@ class CatalogSourceBase(object):
         if index is Ellipsis:
            return self
         elif isinstance(index, slice):
-            start, stop, stride = index.indices(self.size)
-            size = (stop - start) // stride
+            start, stop, step = index.indices(self.size)
+            # from https://stackoverflow.com/a/36188683
+            size = max(0, (stop - start + (step - (1 if step > 0 else -1))) // step)
         else:
             # compute the index slice if needed and get the size
             index = CatalogSourceBase.make_column(index)

--- a/nbodykit/base/catalog.py
+++ b/nbodykit/base/catalog.py
@@ -302,7 +302,12 @@ class CatalogSourceBase(object):
                 size = len(index)
 
         # initialize subset Source of right size
-        subset_data = {col:self[col][index] for col in self}
+        subset_data = {col:self[col][index] for col in self if not self[col].is_default}
+        if size <= 0.51 * self.size:
+            # if the subsample ratio is substential, then always make
+            # a copy to decouple from the original data
+            subset_data = {col:subset_data[col].map_blocks(numpy.copy) for col in subset_data}
+
         cls = self.__class__ if self.base is None else self.base.__class__
         toret = cls._from_columns(size, self.comm, **subset_data)
 

--- a/nbodykit/transform.py
+++ b/nbodykit/transform.py
@@ -107,7 +107,7 @@ def ConstantArray(value, size, chunks=100000):
     """
     ele = numpy.array(value)
     toret = numpy.lib.stride_tricks.as_strided(ele, [size] + list(ele.shape), [0] + list(ele.strides))
-    return da.from_array(toret, chunks=chunks, name='ConstantArray')
+    return da.from_array(toret, chunks=chunks, name=False)
 
 
 def CartesianToEquatorial(pos, observer=[0,0,0]):

--- a/nbodykit/transform.py
+++ b/nbodykit/transform.py
@@ -107,7 +107,7 @@ def ConstantArray(value, size, chunks=100000):
     """
     ele = numpy.array(value)
     toret = numpy.lib.stride_tricks.as_strided(ele, [size] + list(ele.shape), [0] + list(ele.strides))
-    return da.from_array(toret, chunks=chunks)
+    return da.from_array(toret, chunks=chunks, name='ConstantArray')
 
 
 def CartesianToEquatorial(pos, observer=[0,0,0]):


### PR DESCRIPTION
1. Fixed a bug regarding calculation of total sliced size.
2. Give ConstantArray a dask name, such that dask does not hang trying to tokenize huge ConstantArray objects.
3. Use numpy.copy to decouple sliced columns from original data. This improves the memory footprint substantially when slicing is subsampling; previously the new computed array will have references to chunks of the full original data. 
