### PR TITLE
Use dask.store to save a catalog.

### DIFF
--- a/nbodykit/base/catalog.py
+++ b/nbodykit/base/catalog.py
@@ -612,17 +612,7 @@ class CatalogSourceBase(object):
 
                 # save column attrs too
                 with ff.create(dataset, dtype, size, Nfile) as bb:
-                    def save_column(block, block_info=None):
-                        block_info = block_info[0] # first arg
-                        # chunked in the first dimension, thus the start
-                        # of first dim is the offset of write
-                        loffset = block_info['array-location'][0][0]
-                        bb.write(offset + loffset, block)
-                        return 0
-
-                    array1 = array.rechunk(chunks=_global_options['dask_chunk_size'])
-                    # do the writing in parallel
-                    array1.map_blocks(save_column, dtype='i4', name='save-to-disk/%s' % dataset).compute()
+                    array.store(bb, regions=(slice(offset, offset + len(array)),))
 
                     if hasattr(array, 'attrs'):
                         for key in array.attrs:

--- a/nbodykit/base/catalog.py
+++ b/nbodykit/base/catalog.py
@@ -552,7 +552,7 @@ class CatalogSourceBase(object):
         if len(toret) == 1: toret = toret[0]
         return toret
 
-    def save(self, output, columns, dataset=None, datasets=None, header='Header'):
+    def save(self, output, columns=None, dataset=None, datasets=None, header='Header'):
         """
         Save the CatalogSource to a :class:`bigfile.BigFile`.
 
@@ -564,7 +564,7 @@ class CatalogSourceBase(object):
         output : str
             the name of the file to write to
         columns : list of str
-            the names of the columns to save in the file
+            the names of the columns to save in the file, or None to use all columns
         dataset : str, optional
             dataset to store the columns under.
         datasets : list of str, optional
@@ -581,6 +581,7 @@ class CatalogSourceBase(object):
 
         # trim out any default columns; these do not need to be saved as
         # they are automatically available to every Catalog
+        if columns is None: columns = self.columns
         columns = [col for col in columns if not self[col].is_default]
 
         # also make sure no default columns in datasets

--- a/nbodykit/base/tests/test_catalog.py
+++ b/nbodykit/base/tests/test_catalog.py
@@ -51,7 +51,7 @@ def test_save_dataset(comm):
     source.attrs['empty'] = None
 
     # save to a BigFile
-    source.save(tmpfile, source.columns, dataset='1')
+    source.save(tmpfile, dataset='1')
 
     # load as a BigFileCatalog
     source2 = BigFileCatalog(tmpfile, dataset='1', comm=comm)
@@ -68,7 +68,7 @@ def test_save_dataset(comm):
     assert_allclose(allconcat(source['Velocity']), allconcat(source2['Velocity']))
     assert_allclose(allconcat(source['Mass']), allconcat(source2['Mass']))
 
-    subsample.save(tmpfile, subsample.columns, dataset='2')
+    subsample.save(tmpfile, dataset='2')
     subsample2 = BigFileCatalog(tmpfile, dataset='2', comm=comm)
 
     assert_allclose(allconcat(subsample['Position']), allconcat(subsample2['Position']))


### PR DESCRIPTION
The method is recommended by dask devs for storing data to disk. It will prioritize disk write operations, avoiding some issues seen with the map_blocks method. Also may fix a problem about rechunking that @modichirag has been seeing with the HiddenValley simulations.