### PR TITLE
Fix shotnoise estimation of weighted to_mesh() calls.

### DIFF
--- a/nbodykit/base/catalog.py
+++ b/nbodykit/base/catalog.py
@@ -781,7 +781,7 @@ class CatalogSourceBase(object):
         if window is not None:
             resampler = window
             import warnings
-            warnings.warn("The window argument is deprecated. Use `resampler=` instead", DeprecationWarning)
+            warnings.warn("The window argument is deprecated. Use `resampler=` instead", DeprecationWarning, stacklevel=2)
 
         # make sure all of the columns exist
         for col in [weight, selection]:

--- a/nbodykit/source/mesh/tests/test_catalogmesh.py
+++ b/nbodykit/source/mesh/tests/test_catalogmesh.py
@@ -14,11 +14,13 @@ def test_tsc_interlacing(comm):
     source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
 
     # interlacing with TSC
-    mesh = source.to_mesh(window='tsc', Nmesh=64, interlaced=True, compensated=True)
+    mesh = source.to_mesh(resampler='tsc', Nmesh=64, interlaced=True, compensated=True)
 
     # compute the power spectrum -- should be flat shot noise
     # if the compensation worked
     r = FFTPower(mesh, mode='1d', kmin=0.02)
+    # skip a few large scale modes that are noisier (fewer modes)
+    assert_allclose(r.power['power'][5:], 1 / (3e-4), rtol=1e-1)
 
 @MPITest([1])
 def test_paint_empty(comm):
@@ -29,7 +31,7 @@ def test_paint_empty(comm):
     assert source.csize == 0
 
     # interlacing with TSC
-    mesh = source.to_mesh(window='tsc', Nmesh=64, interlaced=True, compensated=True)
+    mesh = source.to_mesh(resampler='tsc', Nmesh=64, interlaced=True, compensated=True)
 
     # compute the power spectrum -- should be flat shot noise
     # if the compensation worked
@@ -45,7 +47,7 @@ def test_paint_chunksize(comm):
     source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
 
     # interlacing with TSC
-    mesh = source.to_mesh(window='tsc', Nmesh=64, interlaced=True, compensated=True)
+    mesh = source.to_mesh(resampler='tsc', Nmesh=64, interlaced=True, compensated=True)
 
     with set_options(paint_chunk_size=source.csize // 4):
         r1 = mesh.compute()
@@ -61,7 +63,7 @@ def test_cic_interlacing(comm):
     source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
 
     # interlacing with TSC
-    mesh = source.to_mesh(window='cic', Nmesh=64, interlaced=True, compensated=True)
+    mesh = source.to_mesh(resampler='cic', Nmesh=64, interlaced=True, compensated=True)
 
     # compute the power spectrum -- should be flat shot noise
     # if the compensation worked
@@ -73,7 +75,7 @@ def test_setters(comm):
     source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
 
     # make the mesh
-    mesh = source.to_mesh(window='cic', Nmesh=64, interlaced=True, compensated=True)
+    mesh = source.to_mesh(resampler='cic', Nmesh=64, interlaced=True, compensated=True)
 
     assert mesh.compensated == True
     mesh.compensated = False
@@ -93,7 +95,7 @@ def test_bad_window(comm):
     source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
 
     # make the mesh
-    mesh = source.to_mesh(window='cic', Nmesh=64, interlaced=True, compensated=True)
+    mesh = source.to_mesh(resampler='cic', Nmesh=64, interlaced=True, compensated=True)
 
     # no such window
     with pytest.raises(Exception):
@@ -105,7 +107,7 @@ def test_no_compensation(comm):
     source = UniformCatalog(nbar=3e-4, BoxSize=512., seed=42, comm=comm)
 
     # make the mesh
-    mesh = source.to_mesh(window='cic', Nmesh=64, interlaced=True, compensated=True)
+    mesh = source.to_mesh(resampler='cic', Nmesh=64, interlaced=True, compensated=True)
 
     # no compensation for this window
     mesh.window = 'db6'


### PR DESCRIPTION
Before this PR we used a simple formula 1 / nbar, which is incorrect if the data is weighted.
@martinjameswhite suggested an alternative formula:

``` V / (sum w**2 / (sum w)**2) ```

It reverts to ```V/N``` when w is unweighted. This expression is also consistent with the shotnoise combination equation in MultipleSpeciesCatalog.

I strongly suspect this was a regression. But anyhow here is the fix.
A test case is added to make sure it does not break again.