### PR TITLE
allow other versions of sphinx.

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -34,7 +34,7 @@ dependencies:
 - halotools
 - fitsio
 - numpydoc
-- sphinx<1.6
+- sphinx
 - IPython
 - pip
 - pip:


### PR DESCRIPTION
The < 1.6 requirement was too restrictive. We can actually build with 1.8.2.