### PR TITLE
Add initial query interface to FileCatalog.

### DIFF
--- a/nbodykit/source/catalog/tests/test_file.py
+++ b/nbodykit/source/catalog/tests/test_file.py
@@ -26,7 +26,7 @@ def test_hdf(comm):
 
     cosmo = cosmology.Planck15
 
-    source = HDFCatalog(tmpfile, root='X', attrs={"Nmesh":32}, comm=comm)
+    source = HDFCatalog(tmpfile, dataset='X', attrs={"Nmesh":32}, comm=comm)
     assert_allclose(source['Position'], dset['Position'])
 
     region = source.query_range(32, 64)


### PR DESCRIPTION
This PR only includes a query interface that supports querying on a range in the file.

It returns a new FileCatalog of the same time, but with references to a new range in the file.

I do not like the current implementation, as it feels like I haven't plumbed through the details of catalog object creation, which seems to be rather convoluted due to hacks like this -- expanding the class for specialized cases ..