### PR TITLE
Center the particles in fiber collision.

### DIFF
--- a/nbodykit/algorithms/fibercollisions.py
+++ b/nbodykit/algorithms/fibercollisions.py
@@ -51,12 +51,12 @@ class FiberCollisions(object):
         # compute the pos
         ra = ArrayCatalog.make_column(ra)
         dec = ArrayCatalog.make_column(dec)
-        pos = SkyToUnitSphere(ra, dec, degrees=degrees).compute()
+        pos = (SkyToUnitSphere(ra, dec, degrees=degrees) + 1.1).compute()
 
         # make the source
         dt = numpy.dtype([('Position', (pos.dtype.str, 3))])
         pos = numpy.squeeze(pos.view(dtype=dt))
-        source = ArrayCatalog(pos, BoxSize=numpy.array([2., 2., 2.]), comm=comm)
+        source = ArrayCatalog(pos, BoxSize=numpy.array([2.2, 2.2, 2.2]), comm=comm)
 
         self.source = source
         self.comm = source.comm


### PR DESCRIPTION
This should address #584. The previous algorithm wraps particles
with periodic boundary and may have connected points near the edges
incorrectly.