### PR TITLE
Reserve label == 0 for FOF unconnected, even if fully connected

### DIFF
--- a/nbodykit/algorithms/fof.py
+++ b/nbodykit/algorithms/fof.py
@@ -253,6 +253,12 @@ def _assign_labels(minid, comm, thresh):
 
     data['fofid'].local[:] = data['fofid'].unique_labels().local[:]
 
+    # unique_labels may miss the 0 index representing disconnected
+    # particles if there are no such particles.
+    # shift the fofoid by 1 in that case.
+    anysmall = comm.allreduce(small.sum()) != 0
+    if not anysmall: data['fofid'].local[:] += 1
+
     data.sort('origind')
 
     label = data['fofid'].local.view('i8').copy()
@@ -272,7 +278,6 @@ def _assign_labels(minid, comm, thresh):
     P = numpy.arange(Nhalo0, dtype=dtype)
     P[arg] = numpy.arange(len(arg), dtype=dtype) + 1
     label = P[label]
-
     return label
 
 def _fof_local(layout, pos, boxsize, ll, comm):

--- a/nbodykit/algorithms/tests/test_fiber_colls.py
+++ b/nbodykit/algorithms/tests/test_fiber_colls.py
@@ -2,6 +2,7 @@ from runtests.mpi import MPITest
 from nbodykit.lab import *
 from nbodykit import setup_logging
 from nbodykit.utils import ScatterArray, GatherArray
+from numpy.testing import assert_array_equal
 
 # debug logging
 setup_logging("debug")
@@ -9,7 +10,7 @@ setup_logging("debug")
 @MPITest([1, 4])
 def test_fibercolls(comm):
 
-    from scipy.spatial.distance import pdist, squareform 
+    from scipy.spatial.distance import pdist, squareform
 
 
     N = 10000
@@ -48,4 +49,18 @@ def test_fibercolls(comm):
         # one object in the clean sample
         ncolls_per = (dists[idx] <= rad).sum(axis=-1)
         assert (ncolls_per >= 1).all(), "objects in 'collided' sample that do not collide with any objects!"
+
+@MPITest([1])
+def test_fibercolls_issue584_4pt(comm):
+    ra = numpy.array([0.,1.,2., 10])
+    dec = numpy.array([0.,0.,0., 0])
+    labels = FiberCollisions(ra,dec,collision_radius=1.5,seed=None, comm=comm).labels
+    assert_array_equal(labels['Collided'].compute(), [0, 1, 0, 0])
+
+@MPITest([1])
+def test_fibercolls_issue584_3pt(comm):
+    ra = numpy.array([0.,1.,2.])
+    dec = numpy.array([0.,0.,0.])
+    labels = FiberCollisions(ra,dec,collision_radius=1.5,seed=None, comm=comm).labels
+    assert_array_equal(labels['Collided'].compute(), [0, 1, 0])
 


### PR DESCRIPTION
This is the reason #584 mis-behaves. 

(https://github.com/bccp/nbodykit/issues/584#issuecomment-494019300)