### PR TITLE
Correct odd multipoles in presence of wide-angle effect

### DIFF
--- a/nbodykit/algorithms/convpower/catalog.py
+++ b/nbodykit/algorithms/convpower/catalog.py
@@ -1,5 +1,4 @@
-#from nbodykit.source.catalog.species import MultipleSpeciesCatalog
-from species import MultipleSpeciesCatalog
+from nbodykit.source.catalog.species import MultipleSpeciesCatalog
 from nbodykit.transform import ConstantArray
 
 import numpy
@@ -168,12 +167,12 @@ class FKPCatalog(MultipleSpeciesCatalog):
             the number of cells per box side; if not specified in `attrs`, this
             must be provided
         dtype : str, dtype, optional
-            the data type of the mesh when painting. dtype='f8' assumes
+            the data type of the mesh when painting. dtype='f8' or 'f4' assumes
             Hermitian symmetry of the input field (\delta(x) = 
             \delta^{*}(-x)), and stores it as an N x N x N/2+1 real array.
             This speeds evaluation of even multipoles but yields 
             incorrect odd multipoles in the presence of the wide-angle effect.
-            dtype='c16' stores the field as an N x N x N complex array 
+            dtype='c16' or 'c8' stores the field as an N x N x N complex array 
             to correctly recover the odd multipoles.
         interlaced : bool, optional
             whether to use interlacing to reduce aliasing when painting the
@@ -207,7 +206,7 @@ class FKPCatalog(MultipleSpeciesCatalog):
             deprecated. set nbar in the call to FKPCatalog()
         """
         from .catalogmesh import FKPCatalogMesh
-        
+
         if window is not None:
             import warnings
             resampler = window

--- a/nbodykit/algorithms/convpower/catalog.py
+++ b/nbodykit/algorithms/convpower/catalog.py
@@ -149,8 +149,7 @@ class FKPCatalog(MultipleSpeciesCatalog):
 
         return BoxSize, BoxCenter
 
-    def to_mesh(self, Nmesh=None, BoxSize=None, BoxCenter=None, fast_even_multipoles=False,
-    dtype='f4', interlaced=False,
+    def to_mesh(self, Nmesh=None, BoxSize=None, BoxCenter=None, dtype='c16', interlaced=False,
                 compensated=False, resampler='cic', fkp_weight='FKPWeight',
                 comp_weight='Weight', selection='Selection',
                 position='Position', bbox_from_species=None, window=None, nbar=None):
@@ -168,12 +167,14 @@ class FKPCatalog(MultipleSpeciesCatalog):
         Nmesh : int, 3-vector, optional
             the number of cells per box side; if not specified in `attrs`, this
             must be provided
-        fast_even_multipoles : bool, optional
-            if True, assume Hermitian symmetry of the input field (\delta(x) = 
-            \delta^{*}(-x)), and store it as an N x N x N/2+1 real array
-            (dtype='f8'). This speeds evaluation of even multipoles but yields 
+        dtype : str, dtype, optional
+            the data type of the mesh when painting. dtype='f8' assumes
+            Hermitian symmetry of the input field (\delta(x) = 
+            \delta^{*}(-x)), and stores it as an N x N x N/2+1 real array.
+            This speeds evaluation of even multipoles but yields 
             incorrect odd multipoles in the presence of the wide-angle effect.
-            If False, store the field as an N x N x N complex array (dtype='c16').
+            dtype='c16' stores the field as an N x N x N complex array 
+            to correctly recover the odd multipoles.
         interlaced : bool, optional
             whether to use interlacing to reduce aliasing when painting the
             particles on the mesh
@@ -207,12 +208,6 @@ class FKPCatalog(MultipleSpeciesCatalog):
         """
         from .catalogmesh import FKPCatalogMesh
         
-        # translate fast_even_multipoles to mesh data type
-        if fast_even_multipoles:
-            dtype = 'f8'
-        else:
-            dtype = 'c16'
-
         if window is not None:
             import warnings
             resampler = window

--- a/nbodykit/algorithms/convpower/catalog.py
+++ b/nbodykit/algorithms/convpower/catalog.py
@@ -1,4 +1,5 @@
-from nbodykit.source.catalog.species import MultipleSpeciesCatalog
+#from nbodykit.source.catalog.species import MultipleSpeciesCatalog
+from species import MultipleSpeciesCatalog
 from nbodykit.transform import ConstantArray
 
 import numpy
@@ -148,7 +149,8 @@ class FKPCatalog(MultipleSpeciesCatalog):
 
         return BoxSize, BoxCenter
 
-    def to_mesh(self, Nmesh=None, BoxSize=None, BoxCenter=None, dtype='f4', interlaced=False,
+    def to_mesh(self, Nmesh=None, BoxSize=None, BoxCenter=None, fast_even_multipoles=False,
+    dtype='f4', interlaced=False,
                 compensated=False, resampler='cic', fkp_weight='FKPWeight',
                 comp_weight='Weight', selection='Selection',
                 position='Position', bbox_from_species=None, window=None, nbar=None):
@@ -166,8 +168,12 @@ class FKPCatalog(MultipleSpeciesCatalog):
         Nmesh : int, 3-vector, optional
             the number of cells per box side; if not specified in `attrs`, this
             must be provided
-        dtype : str, dtype, optional
-            the data type of the mesh when painting
+        fast_even_multipoles : bool, optional
+            if True, assume Hermitian symmetry of the input field (\delta(x) = 
+            \delta^{*}(-x)), and store it as an N x N x N/2+1 real array
+            (dtype='f8'). This speeds evaluation of even multipoles but yields 
+            incorrect odd multipoles in the presence of the wide-angle effect.
+            If False, store the field as an N x N x N complex array (dtype='c16').
         interlaced : bool, optional
             whether to use interlacing to reduce aliasing when painting the
             particles on the mesh
@@ -200,6 +206,12 @@ class FKPCatalog(MultipleSpeciesCatalog):
             deprecated. set nbar in the call to FKPCatalog()
         """
         from .catalogmesh import FKPCatalogMesh
+        
+        # translate fast_even_multipoles to mesh data type
+        if fast_even_multipoles:
+            dtype = 'f8'
+        else:
+            dtype = 'c16'
 
         if window is not None:
             import warnings

--- a/nbodykit/algorithms/convpower/fkp.py
+++ b/nbodykit/algorithms/convpower/fkp.py
@@ -443,7 +443,7 @@ class ConvolvedFFTPower(object):
         pm   = self.first.pm
 
         # setup the 1D-binning
-        muedges = numpy.linspace(0, 1, 2, endpoint=True)
+        muedges = numpy.linspace(-1, 1, 2, endpoint=True)
         edges = [kedges, muedges]
 
         # make a structured array to hold the results

--- a/nbodykit/algorithms/convpower/fkp.py
+++ b/nbodykit/algorithms/convpower/fkp.py
@@ -765,7 +765,7 @@ def _cast_mesh(mesh, Nmesh):
     """
     from .catalog import FKPCatalog
     from .catalogmesh import FKPCatalogMesh
-    
+
     if not isinstance(mesh, (FKPCatalogMesh, FKPCatalog)):
         raise TypeError("input sources should be a FKPCatalog or FKPCatalogMesh")
 

--- a/nbodykit/algorithms/convpower/fkp.py
+++ b/nbodykit/algorithms/convpower/fkp.py
@@ -148,6 +148,9 @@ class ConvolvedFFTPower(object):
             second = _cast_mesh(second, Nmesh=Nmesh)
         else:
             second = first
+        print('first dtype',first.dtype)
+        print('second dtype',second.dtype)
+        #print('first',first)
 
         # data/randoms of second must be same as second
         # only difference can be FKP weight currently
@@ -619,6 +622,7 @@ class ConvolvedFFTPower(object):
                 Aell[islab,...] = norm * A0_1[islab] * Aell[islab].conj()
 
             # project on to 1d k-basis (averaging over mu=[0,1])
+            print('Aell dtype',Aell.dtype)
             proj_result, _ = project_to_basis(Aell, edges)
             result['power_%d' %ell][:] = numpy.squeeze(proj_result[2])
 
@@ -765,13 +769,16 @@ def _cast_mesh(mesh, Nmesh):
     """
     from .catalog import FKPCatalog
     from .catalogmesh import FKPCatalogMesh
-
+    
     if not isinstance(mesh, (FKPCatalogMesh, FKPCatalog)):
         raise TypeError("input sources should be a FKPCatalog or FKPCatalogMesh")
 
+    from catalogmesh import FKPCatalogMesh
+
+
     if isinstance(mesh, FKPCatalog):
         # if input is CatalogSource, use defaults to make it into a mesh
-        mesh = mesh.to_mesh(Nmesh=Nmesh, dtype='f8', compensated=False)
+        mesh = mesh.to_mesh(Nmesh=Nmesh, dtype='c16', compensated=False)
 
     if Nmesh is not None and any(mesh.attrs['Nmesh'] != Nmesh):
         raise ValueError(("Mismatched Nmesh between __init__ and mesh.attrs; "

--- a/nbodykit/algorithms/convpower/fkp.py
+++ b/nbodykit/algorithms/convpower/fkp.py
@@ -148,9 +148,6 @@ class ConvolvedFFTPower(object):
             second = _cast_mesh(second, Nmesh=Nmesh)
         else:
             second = first
-        print('first dtype',first.dtype)
-        print('second dtype',second.dtype)
-        #print('first',first)
 
         # data/randoms of second must be same as second
         # only difference can be FKP weight currently
@@ -622,7 +619,6 @@ class ConvolvedFFTPower(object):
                 Aell[islab,...] = norm * A0_1[islab] * Aell[islab].conj()
 
             # project on to 1d k-basis (averaging over mu=[0,1])
-            print('Aell dtype',Aell.dtype)
             proj_result, _ = project_to_basis(Aell, edges)
             result['power_%d' %ell][:] = numpy.squeeze(proj_result[2])
 
@@ -772,9 +768,6 @@ def _cast_mesh(mesh, Nmesh):
     
     if not isinstance(mesh, (FKPCatalogMesh, FKPCatalog)):
         raise TypeError("input sources should be a FKPCatalog or FKPCatalogMesh")
-
-    from catalogmesh import FKPCatalogMesh
-
 
     if isinstance(mesh, FKPCatalog):
         # if input is CatalogSource, use defaults to make it into a mesh

--- a/nbodykit/algorithms/fftpower.py
+++ b/nbodykit/algorithms/fftpower.py
@@ -611,31 +611,31 @@ def project_to_basis(y3d, edges, los=[0, 0, 1], poles=[]):
         if len(xslab.flat) == 0: continue
 
         # get the bin indices for x on the slab
-        dig_x = numpy.digitize(xslab.flat, x2edges)
+        dig_x = numpy.digitize(xslab.real.flat, x2edges)
 
         # make xslab just x
         xslab **= 0.5
 
         # get the bin indices for mu on the slab
         mu = slab.mu(los) # defined with respect to specified LOS
-        dig_mu = numpy.digitize(mu.flat, muedges)
+        dig_mu = numpy.digitize(mu.real.flat, muedges)
 
         # make the multi-index
         multi_index = numpy.ravel_multi_index([dig_x, dig_mu], (Nx+2,Nmu+2))
 
         # sum up x in each bin (accounting for negative freqs)
         xslab[:] *= slab.hermitian_weights
-        xsum.flat += numpy.bincount(multi_index, weights=xslab.flat, minlength=xsum.size)
+        xsum.flat += numpy.bincount(multi_index, weights=xslab.real.flat, minlength=xsum.size)
 
         # count number of modes in each bin (accounting for negative freqs)
-        Nslab = numpy.ones_like(xslab) * slab.hermitian_weights
+        Nslab = numpy.ones_like(xslab.real) * slab.hermitian_weights
         Nsum.flat += numpy.bincount(multi_index, weights=Nslab.flat, minlength=Nsum.size)
 
         # compute multipoles by weighting by Legendre(ell, mu)
         for iell, ell in enumerate(_poles):
 
             # weight the input 3D array by the appropriate Legendre polynomial
-            weighted_y3d = legpoly[iell](mu) * y3d[slab.index]
+            weighted_y3d = legpoly[iell](mu.real) * y3d[slab.index]
 
             # add conjugate for this kx, ky, kz, corresponding to
             # the (-kx, -ky, -kz) --> need to make mu negative for conjugate
@@ -662,7 +662,7 @@ def project_to_basis(y3d, edges, los=[0, 0, 1], poles=[]):
 
         # sum up the absolute mag of mu in each bin (accounting for negative freqs)
         mu[:] *= slab.hermitian_weights
-        musum.flat += numpy.bincount(multi_index, weights=mu.flat, minlength=musum.size)
+        musum.flat += numpy.bincount(multi_index, weights=mu.real.flat, minlength=musum.size)
 
     # sum binning arrays across all ranks
     xsum  = comm.allreduce(xsum)

--- a/nbodykit/algorithms/fftpower.py
+++ b/nbodykit/algorithms/fftpower.py
@@ -568,7 +568,7 @@ def project_to_basis(y3d, edges, los=[0, 0, 1], poles=[]):
     """
     comm = y3d.pm.comm
     x3d = y3d.x
-    hermitian_symmetric = False
+    hermitian_symmetric = y3d.compressed
 
     from scipy.special import legendre
 

--- a/nbodykit/algorithms/fftpower.py
+++ b/nbodykit/algorithms/fftpower.py
@@ -295,7 +295,7 @@ class FFTPower(FFTBase):
             kedges, kcoords = _find_unique_edges(y3d.x, 2 * numpy.pi / y3d.BoxSize, kmax, y3d.pm.comm)
 
         # project on to the desired basis
-        muedges = numpy.linspace(0, 1, self.attrs['Nmu']+1, endpoint=True)
+        muedges = numpy.linspace(-1, 1, self.attrs['Nmu']+1, endpoint=True)
         edges = [kedges, muedges]
         coords = [kcoords, None]
         result, pole_result = project_to_basis(y3d, edges,
@@ -568,7 +568,7 @@ def project_to_basis(y3d, edges, los=[0, 0, 1], poles=[]):
     """
     comm = y3d.pm.comm
     x3d = y3d.x
-    hermitian_symmetric = numpy.iscomplexobj(y3d)
+    hermitian_symmetric = False
 
     from scipy.special import legendre
 
@@ -618,7 +618,7 @@ def project_to_basis(y3d, edges, los=[0, 0, 1], poles=[]):
 
         # get the bin indices for mu on the slab
         mu = slab.mu(los) # defined with respect to specified LOS
-        dig_mu = numpy.digitize(abs(mu).flat, muedges)
+        dig_mu = numpy.digitize(mu.flat, muedges)
 
         # make the multi-index
         multi_index = numpy.ravel_multi_index([dig_x, dig_mu], (Nx+2,Nmu+2))
@@ -662,7 +662,7 @@ def project_to_basis(y3d, edges, los=[0, 0, 1], poles=[]):
 
         # sum up the absolute mag of mu in each bin (accounting for negative freqs)
         mu[:] *= slab.hermitian_weights
-        musum.flat += numpy.bincount(multi_index, weights=abs(mu).flat, minlength=musum.size)
+        musum.flat += numpy.bincount(multi_index, weights=mu.flat, minlength=musum.size)
 
     # sum binning arrays across all ranks
     xsum  = comm.allreduce(xsum)


### PR DESCRIPTION
Fixed a bug in the nbodykit odd multipoles:
--correct the definition of  "hermitian_symmetric" to use the "compressed" attribute of the mesh
--ensure that coordinates are real even when mesh is complex
--changed default mesh type to 'c16.' added explanation for the user that dtype='f8' is faster for even multipoles but yields incorrect odd multipoles in the presence of the wide-angle effect.