### PR TITLE
fix to meshtools to avoid nans in legpoly at k=0

### DIFF
--- a/nbodykit/meshtools.py
+++ b/nbodykit/meshtools.py
@@ -132,8 +132,13 @@ class MeshSlab(object):
         array_like, (slab.shape)
             the `mu` value at each point in the slab
         """
+        norm = self.norm2()**0.5
+        
         with numpy.errstate(invalid='ignore', divide='ignore'):
-            return sum(self.coords(i) * los[i] for i in range(self.ndim)) / self.norm2()**0.5
+            result = sum(self.coords(i) * los[i] for i in range(self.ndim)) / norm
+        
+        result[norm == 0.0] = 0.0
+        return result
 
     @property
     def nonsingular(self):


### PR DESCRIPTION
At kx=ky=kz=0, in slab.mu(los), the norm2 is 0 and thus mu is nan.  This leads to a nan in legpoly which propagates into nans for all multipoles in the bin containing k=0 for multipoles other than the monopole.  following suggestion of @michaelJwilson, modify SlabIterator.mu in meshtools to fix this issue.