### PR TITLE
Fix wrong shape of complex mesh save.

### DIFF
--- a/nbodykit/base/mesh.py
+++ b/nbodykit/base/mesh.py
@@ -390,11 +390,11 @@ class MeshSource(object):
             field.ravel(out=data)
             with ff.create_from_array(dataset, data) as bb:
                 if isinstance(field, RealField):
-                    bb.attrs['ndarray.shape'] = field.pm.Nmesh
+                    bb.attrs['ndarray.shape'] = field.cshape
                     bb.attrs['BoxSize'] = field.pm.BoxSize
                     bb.attrs['Nmesh'] = field.pm.Nmesh
                 elif isinstance(field, BaseComplexField):
-                    bb.attrs['ndarray.shape'] = field.Nmesh, field.Nmesh, field.Nmesh // 2 + 1
+                    bb.attrs['ndarray.shape'] = field.cshape
                     bb.attrs['BoxSize'] = field.pm.BoxSize
                     bb.attrs['Nmesh'] = field.pm.Nmesh
 

--- a/nbodykit/base/tests/test_mesh.py
+++ b/nbodykit/base/tests/test_mesh.py
@@ -75,7 +75,7 @@ def test_real_save(comm):
         shutil.rmtree(tmpfile)
 
 @MPITest([1,4])
-def test_real_save(comm):
+def test_complex_save(comm):
 
     cosmo = cosmology.Planck15
 
@@ -94,7 +94,7 @@ def test_real_save(comm):
     source.attrs['empty'] = None
 
     # save to bigfile
-    source.save(tmpfile, mode='real')
+    source.save(tmpfile, mode='complex')
 
     # load as a BigFileMesh
     source2 = BigFileMesh(tmpfile, dataset='Field', comm=comm)
@@ -104,7 +104,7 @@ def test_real_save(comm):
         assert_array_equal(source2.attrs[k], source.attrs[k])
 
     # check data
-    assert_array_equal(source2.compute(mode='real'), source.compute(mode='real'))
+    assert_array_equal(source2.compute(mode='complex'), source.compute(mode='complex'))
 
     # cleanup
     comm.barrier()


### PR DESCRIPTION
Also fix the test case which were not testing the complex case.

Reported by wuyiheng@shao.ac.cn:

from nbodykit.lab import ArrayMesh

import numpy
data = numpy.random.random(size=(128,128,128))
mesh = ArrayMesh(data, BoxSize=1.0)
mesh.save("mesh",dataset="LinearDensityK",mode="complex")

And next is the result in the attrs file

BoxSize <f8 3 000000000000F03F000000000000F03F000000000000F03F #HUMANE [ 1 1 1 ]
Nmesh <i8 3 800000000000000080000000000000008000000000000000 #HUMANE [ 128 128 128 ]
ndarray.shape <i8 9 800000000000000080000000000000008000000000000000800000000000000080000000000000008000000000000000410000000000000041000000000000004100000000000000 #HUMANE [ 128 128 128 128 128 128 65 65 65 ]

the shape should have been a 3 vector.