### PR TITLE
Fix `toret.attrs["W2"]`

### DIFF
--- a/nbodykit/source/mesh/catalog.py
+++ b/nbodykit/source/mesh/catalog.py
@@ -382,7 +382,7 @@ class CatalogMesh(MeshSource):
         toret.attrs['shotnoise'] = shotnoise
         toret.attrs['N'] = N
         toret.attrs['W'] = W
-        toret.attrs['W2'] = W
+        toret.attrs['W2'] = W2
         toret.attrs['num_per_cell'] = nbar
 
         csum = toret.csum()


### PR DESCRIPTION
As discussed in issue #670 